### PR TITLE
Refactor/#6

### DIFF
--- a/Mindspace_front/src/hooks/queries/board.ts
+++ b/Mindspace_front/src/hooks/queries/board.ts
@@ -17,6 +17,7 @@ export const useUserPostGetQuery = (
 ) => {
   return useQuery(['userPost', id], () => getPost(id), {
     enabled: isOpen && isActive,
+    staleTime: 1000 * 60 * 5,
   });
 };
 
@@ -24,11 +25,8 @@ export const useDeletePostMutation = (
   successAction: () => void,
   errorAction: (message: string) => void,
 ) => {
-  const queryClient = useQueryClient();
-
   return useMutation(deletePost, {
     onSuccess: () => {
-      queryClient.invalidateQueries(['userPost']);
       successAction();
     },
     onError: (error: AxiosError<ErrorResponse>) => {

--- a/Mindspace_front/src/hooks/queries/board.ts
+++ b/Mindspace_front/src/hooks/queries/board.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { ErrorResponse } from '@/utils/types';
 import {
   createPost,
@@ -24,8 +24,11 @@ export const useDeletePostMutation = (
   successAction: () => void,
   errorAction: (message: string) => void,
 ) => {
+  const queryClient = useQueryClient();
+
   return useMutation(deletePost, {
     onSuccess: () => {
+      queryClient.invalidateQueries(['userPost']);
       successAction();
     },
     onError: (error: AxiosError<ErrorResponse>) => {
@@ -42,8 +45,11 @@ export const useCreatePostMutation = (
   successAction: () => void,
   errorAction: (message: string) => void,
 ) => {
+  const queryClient = useQueryClient();
+
   return useMutation(createPost, {
     onSuccess: () => {
+      queryClient.invalidateQueries(['userPost']);
       successAction();
     },
     onError: (error: AxiosError<ErrorResponse>) => {
@@ -61,8 +67,11 @@ export const useCreatePostMutation = (
 };
 
 export const useUpdatePostMutation = (successAction: () => void) => {
+  const queryClient = useQueryClient();
+
   return useMutation(updatePost, {
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries(['userPost', variables.id]);
       successAction();
     },
   });

--- a/Mindspace_front/src/pages/NodeMap/components/ListModal/index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/components/ListModal/index.tsx
@@ -40,7 +40,7 @@ function ListModal({ listModalOpen, onListRequestClose }: ListModalProps) {
           >
             <span className={styles.header__span}>x</span>
           </button>
-          <PostTable OnClickedId={handleSelecteBoard} />
+          <PostTable onClickedId={handleSelecteBoard} />
         </>
       ) : (
         !isLoading && (

--- a/Mindspace_front/src/pages/NodeMap/components/PostTable/index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/components/PostTable/index.tsx
@@ -2,25 +2,29 @@ import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
 import { AgGridReact } from 'ag-grid-react';
 import { CellClickedEvent } from 'ag-grid-community';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { ModalWidthAtom, ModalHeightAtom } from '@/recoil/state/resizeAtom';
 import { nodeAtom } from '@/recoil/state/nodeAtom';
 import { usePostListGetQuery } from '@/hooks/queries/board';
 
+import { formatDateTime, DateTimeFormat } from '@/utils/dateTime';
+import { BoardResponseDto } from '@/utils/types';
 interface PostTableProps {
-  OnClickedId: (id: number) => void;
+  onClickedId: (id: number) => void;
 }
 
-function PostTable({ OnClickedId }: PostTableProps) {
-  const [rowData, setRowData] = useState([]);
+function PostTable({ onClickedId }: PostTableProps) {
   const selectedNodeInfo = useRecoilValue(nodeAtom);
 
   const { data: postListData } = usePostListGetQuery(selectedNodeInfo.id);
 
-  useEffect(() => {
-    setRowData(postListData);
-  }, [postListData, selectedNodeInfo.id]);
+  const formatPostListData = (dataList: BoardResponseDto[]) => {
+    return dataList?.map((data: BoardResponseDto) => ({
+      ...data,
+      updatedAt: formatDateTime(data.updatedAt, DateTimeFormat.Date),
+    }));
+  };
 
   const [columnDefs] = useState([
     { field: 'title' },
@@ -29,7 +33,7 @@ function PostTable({ OnClickedId }: PostTableProps) {
   ]);
 
   const onRowDataClicked = (params: CellClickedEvent) => {
-    OnClickedId(params.data.id);
+    onClickedId(params.data.id);
   };
 
   const modalWidth = useRecoilValue(ModalWidthAtom);
@@ -47,7 +51,7 @@ function PostTable({ OnClickedId }: PostTableProps) {
       }}
     >
       <AgGridReact
-        rowData={rowData}
+        rowData={formatPostListData(postListData)}
         columnDefs={columnDefs}
         defaultColDef={{
           sortable: true,
@@ -56,7 +60,7 @@ function PostTable({ OnClickedId }: PostTableProps) {
           flex: 1,
         }}
         onCellClicked={onRowDataClicked}
-      ></AgGridReact>
+      />
     </div>
   );
 }

--- a/Mindspace_front/src/pages/NodeMap/components/WriteModal/components/ReadViewer/index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/components/WriteModal/components/ReadViewer/index.tsx
@@ -1,0 +1,115 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect, useState, useRef } from 'react';
+import { Viewer } from '@toast-ui/react-editor';
+import 'tui-color-picker/dist/tui-color-picker.css';
+import '@toast-ui/editor/dist/toastui-editor.css';
+import '@toast-ui/editor/dist/toastui-editor-viewer.css';
+import styles from '../../WriteModal.module.scss';
+
+import { nodeAtom } from '@/recoil/state/nodeAtom';
+import { useRecoilValue } from 'recoil';
+import { useDeletePostMutation } from '@/hooks/queries/board';
+
+import { ViewEditProps } from '@/utils/types';
+
+const ReadViewer = ({
+  nodeData,
+  onEditToggle,
+  onClose,
+  updateNodeInfo,
+}: ViewEditProps) => {
+  const nodeInfo = useRecoilValue(nodeAtom);
+  const viewerRef = useRef(null);
+
+  const datatimeString = nodeData.updatedAt;
+  const date = new Date(datatimeString);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+
+  const datePart = `${year}-${month}-${day}`;
+  const timePart = `${hours}:${minutes}:${seconds}`;
+
+  const [createPostErrorMessage, setCreatePostErrorMessage] =
+    useState<string>('');
+
+  const [deletePostErrorMessage, setDeletePostErrorMessage] =
+    useState<string>('');
+
+  const { mutate: deletePostMutation } = useDeletePostMutation(() => {
+    updateNodeInfo(nodeInfo?.id, false);
+    onEditToggle();
+    onClose();
+  }, setDeletePostErrorMessage);
+
+  const handleDelete = () => {
+    deletePostMutation({
+      id: nodeInfo.id as number,
+    });
+  };
+
+  useEffect(() => {
+    if (createPostErrorMessage) {
+      alert(createPostErrorMessage);
+      setCreatePostErrorMessage('');
+    }
+    if (deletePostErrorMessage) {
+      alert(deletePostErrorMessage);
+      setDeletePostErrorMessage('');
+    }
+  }, [createPostErrorMessage, deletePostErrorMessage]);
+
+  useEffect(() => {
+    if (viewerRef.current) {
+      viewerRef.current.getInstance().setMarkdown(nodeData.content);
+    }
+  }, [nodeData.content]);
+
+  return (
+    <>
+      <div className={styles.header}>
+        <button className={styles.header__button} onClick={onClose}>
+          <span className={styles.header__span}>x</span>
+        </button>
+        <div className={styles.header__left}>
+          <button className={styles.header__button} onClick={handleDelete}>
+            삭제
+          </button>
+          <button className={styles.header__button} onClick={onEditToggle}>
+            수정
+          </button>
+        </div>
+      </div>
+      <div className={styles.content}>
+        <div className={styles.content__title}>
+          <input disabled={false} type="text" value={nodeData.title} />
+
+          <div className={styles.content__dateTime}>
+            <span className={styles.content__date}>{datePart}</span>
+            <span className={styles.content__time}>{timePart}</span>
+          </div>
+        </div>
+        <div className={styles.content__editor}>
+          <div
+            className={`${styles.content__editor} ${styles.editor__content}`}
+          >
+            <div className={styles.content__viewer}>
+              <Viewer
+                ref={viewerRef}
+                initialValue={nodeData.content}
+                usageStatistics={false}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ReadViewer;

--- a/Mindspace_front/src/pages/NodeMap/components/WriteModal/components/ReadViewer/index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/components/WriteModal/components/ReadViewer/index.tsx
@@ -11,6 +11,7 @@ import { useRecoilValue } from 'recoil';
 import { useDeletePostMutation } from '@/hooks/queries/board';
 
 import { ViewEditProps } from '@/utils/types';
+import { formatDateTime, DateTimeFormat } from '@/utils/dateTime';
 
 const ReadViewer = ({
   nodeData,
@@ -20,20 +21,6 @@ const ReadViewer = ({
 }: ViewEditProps) => {
   const nodeInfo = useRecoilValue(nodeAtom);
   const viewerRef = useRef(null);
-
-  const datatimeString = nodeData.updatedAt;
-  const date = new Date(datatimeString);
-
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-
-  const hours = String(date.getHours()).padStart(2, '0');
-  const minutes = String(date.getMinutes()).padStart(2, '0');
-  const seconds = String(date.getSeconds()).padStart(2, '0');
-
-  const datePart = `${year}-${month}-${day}`;
-  const timePart = `${hours}:${minutes}:${seconds}`;
 
   const [createPostErrorMessage, setCreatePostErrorMessage] =
     useState<string>('');
@@ -90,8 +77,12 @@ const ReadViewer = ({
           <input disabled={false} type="text" value={nodeData.title} />
 
           <div className={styles.content__dateTime}>
-            <span className={styles.content__date}>{datePart}</span>
-            <span className={styles.content__time}>{timePart}</span>
+            <span className={styles.content__date}>
+              {formatDateTime(nodeData.updatedAt, DateTimeFormat.Date)}
+            </span>
+            <span className={styles.content__time}>
+              {formatDateTime(nodeData.updatedAt, DateTimeFormat.Time)}
+            </span>
           </div>
         </div>
         <div className={styles.content__editor}>

--- a/Mindspace_front/src/pages/NodeMap/components/WriteModal/components/WriteEditor/Index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/components/WriteModal/components/WriteEditor/Index.tsx
@@ -1,0 +1,112 @@
+// WriteEditor/index.tsx
+import React, { useState, useEffect, useRef } from 'react';
+import { Editor } from '@toast-ui/react-editor';
+import styles from '../../WriteModal.module.scss';
+import { useRecoilValue } from 'recoil';
+import {
+  useUpdatePostMutation,
+  useCreatePostMutation,
+} from '@/hooks/queries/board';
+import { nodeAtom } from '@/recoil/state/nodeAtom';
+import { ViewEditProps } from '@/utils/types';
+
+const WriteEditor = ({
+  nodeData,
+  onEditToggle,
+  onClose,
+  updateNodeInfo,
+}: ViewEditProps) => {
+  const editorRef = useRef(null);
+  const nodeInfo = useRecoilValue(nodeAtom);
+
+  const [edtedTitle, setEditedTitle] = useState(nodeData?.title);
+  const [editedContent, setEditedContent] = useState(nodeData?.content);
+
+  const handleEditorChange = () => {
+    setEditedContent(editorRef.current.getInstance().getMarkdown());
+  };
+
+  const { mutate: updatePostMutation } = useUpdatePostMutation(() => {
+    onEditToggle();
+  });
+  const [createPostErrorMessage, setCreatePostErrorMessage] =
+    useState<string>('');
+
+  const { mutate: createPostMutation } = useCreatePostMutation(() => {
+    updateNodeInfo(nodeInfo?.id, true);
+    onEditToggle();
+  }, setCreatePostErrorMessage);
+
+  const handleSubmit = () => {
+    if (nodeInfo.isWritten) {
+      updatePostMutation({
+        id: nodeInfo.id as number,
+        title: edtedTitle,
+        content: editedContent,
+      });
+      updateNodeInfo(nodeInfo?.id, true);
+    } else {
+      createPostMutation({
+        id: nodeInfo.id as number,
+        title: edtedTitle,
+        content: editedContent,
+      });
+      onEditToggle();
+    }
+  };
+
+  return (
+    <>
+      <div className={styles.header}>
+        <button className={styles.header__button} onClick={onClose}>
+          <span className={styles.header__span}>x</span>
+        </button>
+        <div className={styles.header__left}>
+          {nodeInfo.isWritten ? (
+            <>
+              <button className={styles.header__button} onClick={onEditToggle}>
+                취소
+              </button>
+              <button className={styles.header__button} onClick={handleSubmit}>
+                완료
+              </button>
+            </>
+          ) : (
+            <>
+              <button className={styles.header__button} onClick={handleSubmit}>
+                작성
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+      <div className={styles.content}>
+        <div className={styles.content__title}>
+          <input
+            type="text"
+            placeholder={`[${nodeInfo?.name}] 제목을 입력해주세요`}
+            value={edtedTitle}
+            onChange={(e) => setEditedTitle(e.target.value)}
+          />
+        </div>
+        <div className={styles.content__editor}>
+          <div
+            className={`${styles.content__editor} ${styles.editor__content}`}
+          >
+            <Editor
+              ref={editorRef}
+              initialValue={nodeData?.content}
+              onChange={handleEditorChange}
+              previewStyle="tab"
+              height="100%"
+              initialEditType="markdown"
+              usageStatistics={false}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default WriteEditor;

--- a/Mindspace_front/src/pages/NodeMap/components/WriteModal/components/WriteEditor/Index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/components/WriteModal/components/WriteEditor/Index.tsx
@@ -55,6 +55,13 @@ const WriteEditor = ({
     }
   };
 
+  useEffect(() => {
+    if (createPostErrorMessage) {
+      alert(createPostErrorMessage);
+      setCreatePostErrorMessage('');
+    }
+  }, [createPostErrorMessage]);
+
   return (
     <>
       <div className={styles.header}>

--- a/Mindspace_front/src/pages/NodeMap/components/WriteModal/index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/components/WriteModal/index.tsx
@@ -48,6 +48,12 @@ const WriteModal = ({
     onRequestClose();
   };
 
+  const commonProps = {
+    onClose: handleClose,
+    onEditToggle: () => setIsEditing((prevState) => !prevState),
+    updateNodeInfo: updateNodeInfo,
+  };
+
   return (
     <CustomModal
       isOpen={isOpen}
@@ -57,31 +63,15 @@ const WriteModal = ({
         padding: '1rem',
       }}
     >
-      {!nodeInfo?.isWritten ? (
-        <WriteEditor
-          onClose={handleClose}
-          onEditToggle={() => setIsEditing((prevState) => !prevState)}
-          updateNodeInfo={updateNodeInfo}
-        />
-      ) : isEditing ? (
-        !isLoading && (
+      {!isLoading &&
+        (nodeInfo?.isWritten && !isEditing ? (
+          <ReadViewer nodeData={postData} {...commonProps} />
+        ) : (
           <WriteEditor
-            nodeData={postData}
-            onClose={handleClose}
-            onEditToggle={() => setIsEditing((prevState) => !prevState)}
-            updateNodeInfo={updateNodeInfo}
+            nodeData={isEditing ? postData : undefined}
+            {...commonProps}
           />
-        )
-      ) : (
-        !isLoading && (
-          <ReadViewer
-            nodeData={postData}
-            onClose={handleClose}
-            onEditToggle={() => setIsEditing((prevState) => !prevState)}
-            updateNodeInfo={updateNodeInfo}
-          />
-        )
-      )}
+        ))}
     </CustomModal>
   );
 };

--- a/Mindspace_front/src/pages/NodeMap/components/WriteModal/index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/components/WriteModal/index.tsx
@@ -1,20 +1,16 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect, useState } from 'react';
-import { Editor, Viewer } from '@toast-ui/react-editor';
 import 'tui-color-picker/dist/tui-color-picker.css';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import '@toast-ui/editor/dist/toastui-editor-viewer.css';
-import styles from './WriteModal.module.scss';
 import { WriteModalProps } from '@/utils/types';
 import CustomModal from '@/components/CustomModal';
 import { nodeAtom } from '@/recoil/state/nodeAtom';
 import { useRecoilValue } from 'recoil';
-import {
-  useUserPostGetQuery,
-  useCreatePostMutation,
-  useUpdatePostMutation,
-  useDeletePostMutation,
-} from '@/hooks/queries/board';
+import { useUserPostGetQuery } from '@/hooks/queries/board';
+
+import WriteEditor from './components/WriteEditor';
+import ReadViewer from './components/ReadViewer';
 
 const WriteModal = ({
   isOpen,
@@ -22,74 +18,13 @@ const WriteModal = ({
   updateNodeInfo,
 }: WriteModalProps) => {
   const nodeInfo = useRecoilValue(nodeAtom);
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [isWritten, setIsWritten] = useState(nodeInfo.isWritten);
-  const [initTitle, setInitTitle] = useState(title);
-  const [initEditedContent, setInitEditedContent] = useState(content);
-  const [isEditing, setIsEditing] = useState(true);
-  const [dataIsLoading, setDataIsLoading] = useState(true);
-  const [boardId, setBoardId] = useState(0);
-  const editorRef = React.useRef(null);
-  const [date, setDate] = useState('');
-  const [time, setTime] = useState('');
-
-  const initialize = () => {
-    setTitle('');
-    setContent('');
-    setIsEditing(true);
-  };
-
-  const handleEditorChange = () => {
-    setContent(editorRef.current.getInstance().getMarkdown());
-  };
+  const [isEditing, setIsEditing] = useState(false);
 
   const [createPostErrorMessage, setCreatePostErrorMessage] =
     useState<string>('');
 
-  const { mutate: createPostMutation } = useCreatePostMutation(() => {
-    setDataIsLoading(false);
-    setIsEditing(false);
-    setIsWritten(true);
-    updateNodeInfo(nodeInfo?.id, true);
-  }, setCreatePostErrorMessage);
-
-  const handleFirstWrite = () => {
-    createPostMutation({
-      id: nodeInfo.id as number,
-      title: title,
-      content: content,
-    });
-  };
-
-  const { mutate: updatePostMutation } = useUpdatePostMutation(() => {
-    setInitTitle(title);
-    setInitEditedContent(content);
-    setIsEditing(false);
-  });
-
-  const handleSubmit = () => {
-    updatePostMutation({
-      id: nodeInfo.id as number,
-      title: title,
-      content: content,
-    });
-  };
-
   const [deletePostErrorMessage, setDeletePostErrorMessage] =
     useState<string>('');
-
-  const { mutate: deletePostMutation } = useDeletePostMutation(() => {
-    updateNodeInfo(nodeInfo?.id, false);
-    setIsWritten(false);
-    onRequestClose();
-  }, setDeletePostErrorMessage);
-
-  const handleDelete = () => {
-    deletePostMutation({
-      id: nodeInfo.id as number,
-    });
-  };
 
   useEffect(() => {
     if (createPostErrorMessage) {
@@ -102,174 +37,50 @@ const WriteModal = ({
     }
   }, [createPostErrorMessage, deletePostErrorMessage]);
 
-  const handleCancel = () => {
-    setIsEditing(false);
-    setContent(initEditedContent);
-    setTitle(initTitle);
-  };
-
   const { data: postData, isLoading } = useUserPostGetQuery(
     nodeInfo.id as number,
     isOpen,
     nodeInfo?.isWritten,
   );
 
-  useEffect(() => {
+  const handleClose = () => {
     setIsEditing(false);
-    setIsWritten(nodeInfo.isWritten);
-
-    if (isOpen && nodeInfo?.isWritten) {
-      if (isLoading) {
-        alert('로딩중입니다. 잠시만 기다려주세요.');
-      } else if (postData) {
-        const datatimeString = postData.updatedAt;
-        const [datePart, timePart] = datatimeString.split('T');
-        const timeString = timePart.split('.')[0];
-        setTitle(postData.title);
-        setContent(postData.content);
-        setInitTitle(postData.title);
-        setInitEditedContent(postData.content);
-        setBoardId(postData.id);
-        setDate(datePart);
-        setTime(timeString);
-      }
-    } else {
-      initialize();
-    }
-  }, [boardId, isOpen, nodeInfo, isLoading]);
+    onRequestClose();
+  };
 
   return (
     <CustomModal
       isOpen={isOpen}
-      onRequestClose={onRequestClose}
+      onRequestClose={handleClose}
       resizable
       style={{
         padding: '1rem',
       }}
     >
-      {isWritten ? (
-        <>
-          <div className={styles.header}>
-            <button className={styles.header__button} onClick={onRequestClose}>
-              <span className={styles.header__span}>x</span>
-            </button>
-            <div className={styles.header__left}>
-              {isEditing ? (
-                <>
-                  <button
-                    className={styles.header__button}
-                    onClick={handleCancel}
-                  >
-                    취소
-                  </button>
-                  <button
-                    className={styles.header__button}
-                    onClick={handleSubmit}
-                  >
-                    완료
-                  </button>
-                </>
-              ) : (
-                <>
-                  <button
-                    className={styles.header__button}
-                    onClick={handleDelete}
-                  >
-                    삭제
-                  </button>
-                  <button
-                    className={styles.header__button}
-                    onClick={() => setIsEditing(true)}
-                  >
-                    수정
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-          <div className={styles.content}>
-            <div className={styles.content__title}>
-              <input
-                disabled={!isEditing}
-                type="text"
-                placeholder={`[${nodeInfo?.name}] 제목을 입력해주세요`}
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-              />
-              {!isEditing && (
-                <div className={styles.content__dateTime}>
-                  <span className={styles.content__date}>{date}</span>
-                  <span className={styles.content__time}>{time}</span>
-                </div>
-              )}
-            </div>
-            <div className={styles.content__editor}>
-              <div
-                className={`${styles.content__editor} ${styles.editor__content}`}
-              >
-                {isEditing ? (
-                  <Editor
-                    initialValue={content}
-                    onChange={handleEditorChange}
-                    previewStyle="tab"
-                    height="100%"
-                    initialEditType="markdown"
-                    usageStatistics={false}
-                    ref={editorRef}
-                  />
-                ) : (
-                  !dataIsLoading && (
-                    <div className={styles.content__viewer}>
-                      <Viewer initialValue={content} usageStatistics={false} />
-                    </div>
-                  )
-                )}
-              </div>
-            </div>
-          </div>
-        </>
+      {!nodeInfo?.isWritten ? (
+        <WriteEditor
+          onClose={handleClose}
+          onEditToggle={() => setIsEditing((prevState) => !prevState)}
+          updateNodeInfo={updateNodeInfo}
+        />
+      ) : isEditing ? (
+        !isLoading && (
+          <WriteEditor
+            nodeData={postData}
+            onClose={handleClose}
+            onEditToggle={() => setIsEditing((prevState) => !prevState)}
+            updateNodeInfo={updateNodeInfo}
+          />
+        )
       ) : (
-        <>
-          <div className={styles.header}>
-            <button className={styles.header__button} onClick={onRequestClose}>
-              <span className={styles.header__span}>x</span>
-            </button>
-            <div className={styles.header__left}>
-              <button
-                className={styles.header__button}
-                onClick={handleFirstWrite}
-              >
-                작성
-              </button>
-            </div>
-          </div>
-          <div className={styles.content}>
-            <div className={styles.content__title}>
-              <input
-                disabled={!isEditing}
-                type="text"
-                placeholder={`[${nodeInfo?.name}] 제목을 입력해주세요`}
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-              />
-            </div>
-            <div className={styles.content__editor}>
-              <div
-                className={`${styles.content__editor} ${styles.editor__content}`}
-              >
-                <Editor
-                  initialValue={content}
-                  onChange={handleEditorChange}
-                  previewStyle="tab"
-                  height="100%"
-                  initialEditType="markdown"
-                  usageStatistics={false}
-                  ref={editorRef}
-                />
-              </div>
-            </div>
-          </div>
-        </>
+        !isLoading && (
+          <ReadViewer
+            nodeData={postData}
+            onClose={handleClose}
+            onEditToggle={() => setIsEditing((prevState) => !prevState)}
+            updateNodeInfo={updateNodeInfo}
+          />
+        )
       )}
     </CustomModal>
   );

--- a/Mindspace_front/src/pages/NodeMap/index.tsx
+++ b/Mindspace_front/src/pages/NodeMap/index.tsx
@@ -139,6 +139,7 @@ const NodeMap = () => {
       links: nodeData.links,
     };
     setNodeData(updatedNodeData);
+    setNodeInfo({ ...nodeInfo, isWritten: isWritten });
   };
 
   useEffect(() => {

--- a/Mindspace_front/src/utils/dateTime.ts
+++ b/Mindspace_front/src/utils/dateTime.ts
@@ -1,0 +1,32 @@
+export enum DateTimeFormat {
+  Date,
+  Time,
+  DateTime,
+}
+
+export function formatDateTime(
+  datetimeString: string,
+  format: DateTimeFormat = DateTimeFormat.DateTime,
+): string {
+  const date = new Date(datetimeString);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+
+  const datePart = `${year}-${month}-${day}`;
+  const timePart = `${hours}:${minutes}:${seconds}`;
+
+  switch (format) {
+    case DateTimeFormat.Date:
+      return datePart;
+    case DateTimeFormat.Time:
+      return timePart;
+    case DateTimeFormat.DateTime:
+      return `${datePart} ${timePart}`;
+  }
+}

--- a/Mindspace_front/src/utils/types.ts
+++ b/Mindspace_front/src/utils/types.ts
@@ -61,6 +61,22 @@ export interface WriteModalProps {
   updateNodeInfo: (id: number | string, isWritten: boolean) => void;
 }
 
+interface BoardResponseDto {
+  id: number;
+  userNickname: string;
+  title: string;
+  content: string;
+  updatedAt: string;
+}
+
+// WriteEditor || ReadViwer
+export interface ViewEditProps {
+  nodeData?: BoardResponseDto;
+  onClose: () => void;
+  onEditToggle: () => void;
+  updateNodeInfo: (id: number | undefined, isWritten: boolean) => void;
+}
+
 // ListModal
 export interface ListModalProps {
   listModalOpen: boolean;

--- a/Mindspace_front/src/utils/types.ts
+++ b/Mindspace_front/src/utils/types.ts
@@ -61,7 +61,7 @@ export interface WriteModalProps {
   updateNodeInfo: (id: number | string, isWritten: boolean) => void;
 }
 
-interface BoardResponseDto {
+export interface BoardResponseDto {
   id: number;
   userNickname: string;
   title: string;


### PR DESCRIPTION
## Summary
이전 정보가 보여지는 문제 ( 수정 후 새로 연 모달창에서) 및 같은 api를 캐싱하지 않고 보내는 문제 수정 및 코드 리펙토링

## Description
- WriteModal 컴포넌트 ReadView, WrtieEditor 하위 컴포넌트로 분리 
- utils/dateTime 의 날짜정보 파싱 별도의 유틸함수로 분리

## Screenshots
*실행 결과 스크린샷*

1. 이전 정보 업데이트에 대한 정보 갱신 확인

![6+1](https://github.com/techeer-sv/Mindspace/assets/78795820/9b7c7455-8210-4cf1-8b6d-46c2b392e007)


2. 동일한 게시판을 클릭 했을 때 api를 계속 보내지 않는 지 확인

![6](https://github.com/techeer-sv/Mindspace/assets/78795820/cafc62f0-2989-4ebf-b66a-2b54f37a065f)


## Test Checklist
- [x] 수정 / 삭제에 대한 이전 데이터 렌더링 문제 해결 확인
- [x] 같은 노드 게시판을 눌렀을 때 api를 재호출하지 않는지 확인