### PR TITLE
Feat/#5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # neo4j data
 neo4j
+
+# webStorm
+.idea

--- a/Mindspace_back/package.json
+++ b/Mindspace_back/package.json
@@ -25,8 +25,12 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.0",
+    "@types/bcrypt": "^5.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.17"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/Mindspace_back/pnpm-lock.yaml
+++ b/Mindspace_back/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   '@nestjs/common':
     specifier: ^10.0.0
-    version: 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+    version: 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
   '@nestjs/config':
     specifier: ^3.0.1
     version: 3.0.1(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
@@ -20,12 +20,24 @@ dependencies:
   '@nestjs/typeorm':
     specifier: ^10.0.0
     version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)(typeorm@0.3.17)
+  '@types/bcrypt':
+    specifier: ^5.0.0
+    version: 5.0.0
+  class-transformer:
+    specifier: ^0.5.1
+    version: 0.5.1
+  class-validator:
+    specifier: ^0.14.0
+    version: 0.14.0
   reflect-metadata:
     specifier: ^0.1.13
     version: 0.1.13
   rxjs:
     specifier: ^7.8.1
     version: 7.8.1
+  typeorm:
+    specifier: ^0.3.17
+    version: 0.3.17(pg@8.11.3)(ts-node@10.9.1)
 
 devDependencies:
   '@nestjs/cli':
@@ -36,7 +48,7 @@ devDependencies:
     version: 10.0.0(chokidar@3.5.3)(typescript@5.1.3)
   '@nestjs/swagger':
     specifier: ^7.1.11
-    version: 7.1.11(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)(reflect-metadata@0.1.13)
+    version: 7.1.11(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
   '@nestjs/testing':
     specifier: ^10.0.0
     version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)(@nestjs/platform-express@10.0.0)
@@ -883,7 +895,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nestjs/common@10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1):
+  /@nestjs/common@10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1):
     resolution: {integrity: sha512-Fa2GDQJrO5TTTcpISWfm0pdPS62V+8YbxeG5CA01zMUI+dCO3v3oFf+BSjqCGUUo7GDNzDsjAejwGXuqA54RPw==}
     peerDependencies:
       class-transformer: '*'
@@ -896,6 +908,8 @@ packages:
       class-validator:
         optional: true
     dependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.0
       iterare: 1.2.1
       reflect-metadata: 0.1.13
       rxjs: 7.8.1
@@ -908,7 +922,7 @@ packages:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
       reflect-metadata: ^0.1.13
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       dotenv: 16.3.1
       dotenv-expand: 10.0.0
       lodash: 4.17.21
@@ -934,7 +948,7 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/platform-express': 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
@@ -947,7 +961,7 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@nestjs/mapped-types@2.0.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13):
+  /@nestjs/mapped-types@2.0.2(@nestjs/common@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-V0izw6tWs6fTp9+KiiPUbGHWALy563Frn8X6Bm87ANLRuE46iuBMD5acKBDP5lKL/75QFvrzSJT7HkCbB0jTpg==}
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
@@ -960,7 +974,9 @@ packages:
       class-validator:
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      class-transformer: 0.5.1
+      class-validator: 0.14.0
       reflect-metadata: 0.1.13
     dev: true
 
@@ -970,7 +986,7 @@ packages:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       body-parser: 1.20.2
       cors: 2.8.5
@@ -995,7 +1011,7 @@ packages:
       - chokidar
     dev: true
 
-  /@nestjs/swagger@7.1.11(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)(reflect-metadata@0.1.13):
+  /@nestjs/swagger@7.1.11(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-EneFcucWC4a0n/FVd1Hg1MRugt65vL/1RDsQMqhMRfVw6IbYWuiKh51TNI4QwOPrRGiR1ry8qHJCBcTX9cl89Q==}
     peerDependencies:
       '@fastify/static': ^6.0.0
@@ -1012,9 +1028,11 @@ packages:
       class-validator:
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
-      '@nestjs/mapped-types': 2.0.2(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
+      '@nestjs/mapped-types': 2.0.2(@nestjs/common@10.0.0)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
+      class-transformer: 0.5.1
+      class-validator: 0.14.0
       js-yaml: 4.1.0
       lodash: 4.17.21
       path-to-regexp: 3.2.0
@@ -1035,7 +1053,7 @@ packages:
       '@nestjs/platform-express':
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/platform-express': 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
       tslib: 2.5.3
@@ -1050,7 +1068,7 @@ packages:
       rxjs: ^7.2.0
       typeorm: ^0.3.0
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       reflect-metadata: 0.1.13
       rxjs: 7.8.1
@@ -1150,6 +1168,12 @@ packages:
     dependencies:
       '@babel/types': 7.22.17
     dev: true
+
+  /@types/bcrypt@5.0.0:
+    resolution: {integrity: sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==}
+    dependencies:
+      '@types/node': 20.3.1
+    dev: false
 
   /@types/body-parser@1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
@@ -1299,6 +1323,9 @@ packages:
     dependencies:
       '@types/superagent': 4.1.18
     dev: true
+
+  /@types/validator@13.11.1:
+    resolution: {integrity: sha512-d/MUkJYdOeKycmm75Arql4M5+UuXmf4cHdHKsyw1GcvnNgL6s77UkgSgJ8TE/rI5PYsnwYq5jkcWBLuN/MpQ1A==}
 
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -1990,6 +2017,16 @@ packages:
   /cjs-module-lexer@1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
     dev: true
+
+  /class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  /class-validator@0.14.0:
+    resolution: {integrity: sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==}
+    dependencies:
+      '@types/validator': 13.11.1
+      libphonenumber-js: 1.10.44
+      validator: 13.11.0
 
   /cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -3704,6 +3741,9 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /libphonenumber-js@1.10.44:
+    resolution: {integrity: sha512-svlRdNBI5WgBjRC20GrCfbFiclbF0Cx+sCcQob/C1r57nsoq0xg8r65QbTyVyweQIlB33P+Uahyho6EMYgcOyQ==}
+
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
@@ -5228,6 +5268,10 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
     dev: true
+
+  /validator@13.11.0:
+    resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
+    engines: {node: '>= 0.10'}
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}

--- a/Mindspace_back/src/app.module.ts
+++ b/Mindspace_back/src/app.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 import { Neo4jModule } from 'nest-neo4j';
+import { UserModule } from './user/user.module';
+import { User } from './user/entities/user.entity';
 
 @Module({
   imports: [
@@ -16,7 +18,7 @@ import { Neo4jModule } from 'nest-neo4j';
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
-      entities: [],
+      entities: [User],
       synchronize: true, // 개발 환경에서만 true로 설정
     }),
     Neo4jModule.forRoot({
@@ -26,6 +28,7 @@ import { Neo4jModule } from 'nest-neo4j';
       username: process.env.NEO4J_USERNAME,
       password: process.env.NEO4J_PASSWORD,
     }),
+    UserModule,
   ],
   controllers: [],
   providers: [],

--- a/Mindspace_back/src/global/common/timeStamp.ts
+++ b/Mindspace_back/src/global/common/timeStamp.ts
@@ -1,0 +1,9 @@
+import { CreateDateColumn, UpdateDateColumn, BaseEntity } from 'typeorm';
+
+export abstract class Timestamp extends BaseEntity {
+  @CreateDateColumn({ type: 'timestamp' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updatedAt: Date;
+}

--- a/Mindspace_back/src/user/dto/user-login-request.dto.ts
+++ b/Mindspace_back/src/user/dto/user-login-request.dto.ts
@@ -1,5 +1,5 @@
 import { IsNotEmpty } from 'class-validator';
-import {ApiProperty} from "@nestjs/swagger";
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UserLoginRequestDto {
   @ApiProperty({ description: 'email', example: 'user@example.com' })

--- a/Mindspace_back/src/user/dto/user-login-request.dto.ts
+++ b/Mindspace_back/src/user/dto/user-login-request.dto.ts
@@ -1,9 +1,12 @@
 import { IsNotEmpty } from 'class-validator';
+import {ApiProperty} from "@nestjs/swagger";
 
 export class UserLoginRequestDto {
+  @ApiProperty({ description: 'email', example: 'user@example.com' })
   @IsNotEmpty()
   email: string;
 
+  @ApiProperty({ description: 'password', example: '1234' })
   @IsNotEmpty()
   password: string;
 }

--- a/Mindspace_back/src/user/dto/user-login-request.dto.ts
+++ b/Mindspace_back/src/user/dto/user-login-request.dto.ts
@@ -1,0 +1,9 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class UserLoginRequestDto {
+  @IsNotEmpty()
+  email: string;
+
+  @IsNotEmpty()
+  password: string;
+}

--- a/Mindspace_back/src/user/dto/user-response.dto.ts
+++ b/Mindspace_back/src/user/dto/user-response.dto.ts
@@ -1,0 +1,14 @@
+export class UserResponseDto {
+  id: number;
+  email: string;
+  password: string;
+  nickname: string;
+
+  // 모든 필드를 파라미터로 받는 생성자 정의
+  constructor(id: number, email: string, password: string, nickname: string) {
+    this.id = id;
+    this.email = email;
+    this.password = password;
+    this.nickname = nickname;
+  }
+}

--- a/Mindspace_back/src/user/dto/user-signup-request.dto.ts
+++ b/Mindspace_back/src/user/dto/user-signup-request.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class UserSignupRequestDto {
+  @IsNotEmpty()
+  email: string;
+
+  @IsNotEmpty()
+  password: string;
+
+  @IsNotEmpty()
+  nickname: string;
+}

--- a/Mindspace_back/src/user/dto/user-signup-request.dto.ts
+++ b/Mindspace_back/src/user/dto/user-signup-request.dto.ts
@@ -1,12 +1,16 @@
 import { IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UserSignupRequestDto {
+  @ApiProperty({ description: 'email', example: 'user@example.com' })
   @IsNotEmpty()
   email: string;
 
+  @ApiProperty({ description: 'password', example: '1234' })
   @IsNotEmpty()
   password: string;
 
+  @ApiProperty({ description: 'nickname', example: 'user' })
   @IsNotEmpty()
   nickname: string;
 }

--- a/Mindspace_back/src/user/dto/user.mapper.ts
+++ b/Mindspace_back/src/user/dto/user.mapper.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { User } from '../entities/user.entity';
+import { UserSignupRequestDto } from './user-signup-request.dto';
+import { UserResponseDto } from './user-response.dto';
+
+@Injectable()
+export class UserMapper {
+  DtoToEntity(userRequestDto: UserSignupRequestDto): User {
+    const user = new User();
+    user.email = userRequestDto.email;
+    user.password = userRequestDto.password;
+    user.nickname = userRequestDto.nickname;
+    return user;
+  }
+
+  DtoFromEntity(user: User): UserResponseDto {
+    return {
+      id: user.id,
+      email: user.email,
+      password: user.password,
+      nickname: user.nickname,
+    };
+  }
+}

--- a/Mindspace_back/src/user/entities/user.entity.ts
+++ b/Mindspace_back/src/user/entities/user.entity.ts
@@ -1,0 +1,20 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Timestamp } from '../../global/common/timeStamp';
+
+@Entity('user')
+export class User extends Timestamp {
+  @PrimaryGeneratedColumn('increment', { name: 'user_id' })
+  id: number;
+
+  @Column({ name: 'email', type: 'varchar', nullable: false })
+  email: string;
+
+  @Column({ name: 'password', type: 'varchar', nullable: false })
+  password: string;
+
+  @Column({ name: 'nickname', type: 'varchar', nullable: false })
+  nickname: string;
+
+  @Column({ name: 'is_active', type: 'boolean', default: true })
+  isActive: boolean;
+}

--- a/Mindspace_back/src/user/user.controller.spec.ts
+++ b/Mindspace_back/src/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserController } from './user.controller';
+
+describe('UserController', () => {
+  let controller: UserController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserController],
+    }).compile();
+
+    controller = module.get<UserController>(UserController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/Mindspace_back/src/user/user.controller.ts
+++ b/Mindspace_back/src/user/user.controller.ts
@@ -1,0 +1,47 @@
+import { Controller, Post, Get, Body, HttpStatus, Res } from '@nestjs/common';
+import { UserService } from './user.service';
+import { UserMapper } from './dto/user.mapper';
+import { UserSignupRequestDto } from './dto/user-signup-request.dto';
+import { UserLoginRequestDto } from './dto/user-login-request.dto';
+import { Response } from 'express';
+import {ApiOperation, ApiTags} from '@nestjs/swagger';
+
+@ApiTags('User')
+@Controller('api/v1/user')
+export class UserController {
+  constructor(
+    private readonly userService: UserService,
+    private readonly userMapper: UserMapper,
+  ) {}
+
+  @ApiOperation({ summary: '회원가입' })
+  @Post('/signup')
+  async signupUser(
+    @Body() userSignupRequestDto: UserSignupRequestDto,
+    @Res() res: Response,
+  ): Promise<void> {
+    const signupResult = await this.userService.signupUser(
+      userSignupRequestDto,
+    );
+    const response = this.userMapper.DtoFromEntity(signupResult);
+    res.status(HttpStatus.CREATED).json(response);
+  }
+
+  @ApiOperation({ summary: '로그인' })
+  @Post('/login')
+  async loginUser(
+    @Body() userLoginRequestDto: UserLoginRequestDto,
+    @Res() res: Response,
+  ): Promise<void> {
+    const loginResult = await this.userService.loginUser(userLoginRequestDto);
+    const response = this.userMapper.DtoFromEntity(loginResult);
+    res.status(HttpStatus.OK).json(response);
+  }
+
+  @ApiOperation({ summary: '회원 전체 조회' })
+  @Get('/all')
+  async getAllUser(@Res() res: Response): Promise<void> {
+    const users = await this.userService.getAllUser();
+    res.status(HttpStatus.OK).json(users);
+  }
+}

--- a/Mindspace_back/src/user/user.controller.ts
+++ b/Mindspace_back/src/user/user.controller.ts
@@ -4,7 +4,7 @@ import { UserMapper } from './dto/user.mapper';
 import { UserSignupRequestDto } from './dto/user-signup-request.dto';
 import { UserLoginRequestDto } from './dto/user-login-request.dto';
 import { Response } from 'express';
-import {ApiOperation, ApiTags} from '@nestjs/swagger';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('User')
 @Controller('api/v1/user')

--- a/Mindspace_back/src/user/user.module.ts
+++ b/Mindspace_back/src/user/user.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { UserService } from './user.service';
+import { UserController } from './user.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { UserMapper } from './dto/user.mapper';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [UserService, UserMapper],
+  controllers: [UserController],
+})
+export class UserModule {}

--- a/Mindspace_back/src/user/user.service.spec.ts
+++ b/Mindspace_back/src/user/user.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/Mindspace_back/src/user/user.service.ts
+++ b/Mindspace_back/src/user/user.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from './entities/user.entity';
+import { UserSignupRequestDto } from './dto/user-signup-request.dto';
+import { UserLoginRequestDto } from './dto/user-login-request.dto';
+import { UserMapper } from './dto/user.mapper';
+
+@Injectable()
+export class UserService {
+  constructor(
+    @InjectRepository(User) private readonly userRepository: Repository<User>,
+    private readonly userMapper: UserMapper,
+  ) {}
+
+  async signupUser(userSignupRequestDto: UserSignupRequestDto): Promise<User> {
+    const userEntity = this.userMapper.DtoToEntity(userSignupRequestDto);
+    return await this.userRepository.save(userEntity);
+  }
+
+  async loginUser(userLoginRequestDto: UserLoginRequestDto): Promise<User> {
+    const user = await this.userRepository.findOne({
+      where: { email: userLoginRequestDto.email },
+    });
+
+    if (!user) {
+      throw new Error('해당 이메일로 가입한 사용자 없음');
+    }
+
+    if (user.password !== userLoginRequestDto.password) {
+      throw new Error('비밀번호 오류');
+    }
+
+    // TODO: jwt token
+    return user;
+  }
+
+  async getAllUser(): Promise<User[]> {
+    return await this.userRepository.find();
+  }
+}


### PR DESCRIPTION
## Summary
회원가입, 로그인 api 구현

## Description
- 회원가입과 로그인 api를 구현했습니다.
- 회원가입과 로그인 api에서 기존에 적용한 예외처리는 적용하지 않았습니다. 추후 PR로 올리겠습니다.

## Screenshots
![image](https://github.com/techeer-sv/Mindspace/assets/105929978/9b01c48d-0baf-40b1-a7fe-9ca8eb44832f)

## 실행방법
Mindspace_back폴더 경로에서 DB를 도커로 실행 후 nest를 로컬에서 실행
```
npm i -g pnpm
pnpm i
pnpm start:dev
``` 
swagger나 postman으로 테스트

OR

`docker compose up --build` 후 swagger나 postman으로 테스트

## Test Checklist
- [x] 회원가입 api
- [x] 로그인 api