### PR TITLE
feat/#11

### DIFF
--- a/Mindspace_back/src/app.module.ts
+++ b/Mindspace_back/src/app.module.ts
@@ -9,7 +9,7 @@ import { User } from './user/entities/user.entity';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true, // 전체적으로 사용
-      cache: true,
+      // cache: true,
     }),
     TypeOrmModule.forRoot({
       type: 'postgres',
@@ -24,7 +24,7 @@ import { User } from './user/entities/user.entity';
     Neo4jModule.forRoot({
       scheme: 'neo4j',
       host: process.env.NEO4J_HOST,
-      port: Number(process.env.NEO4J_PORT),
+      port: process.env.NEO4J_PORT,
       username: process.env.NEO4J_USERNAME,
       password: process.env.NEO4J_PASSWORD,
     }),

--- a/Mindspace_back/src/global/common/customException.ts
+++ b/Mindspace_back/src/global/common/customException.ts
@@ -1,0 +1,17 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class CustomException extends HttpException {
+  constructor(
+    private readonly _errorCode: string,
+    message: string,
+    status: HttpStatus,
+  ) {
+    super(
+      {
+        errorCode: _errorCode,
+        message: message,
+      },
+      status,
+    );
+  }
+}

--- a/Mindspace_back/src/user/dto/user-nickname-response.dto.ts
+++ b/Mindspace_back/src/user/dto/user-nickname-response.dto.ts
@@ -1,0 +1,3 @@
+export class UserNicknameResponseDto {
+  constructor(public nickname: string) {}
+}

--- a/Mindspace_back/src/user/dto/user.mapper.ts
+++ b/Mindspace_back/src/user/dto/user.mapper.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { User } from '../entities/user.entity';
 import { UserSignupRequestDto } from './user-signup-request.dto';
 import { UserResponseDto } from './user-response.dto';
+import { UserNicknameResponseDto } from './user-nickname-response.dto';
 
 @Injectable()
 export class UserMapper {
@@ -18,6 +19,12 @@ export class UserMapper {
       id: user.id,
       email: user.email,
       password: user.password,
+      nickname: user.nickname,
+    };
+  }
+
+  nicknameDtoFromEntity(user: User): UserNicknameResponseDto {
+    return {
       nickname: user.nickname,
     };
   }

--- a/Mindspace_back/src/user/exception/errorResponse.ts
+++ b/Mindspace_back/src/user/exception/errorResponse.ts
@@ -1,0 +1,32 @@
+import { HttpStatus } from '@nestjs/common';
+import { CustomException } from '../../global/common/customException';
+
+export class UserNotFoundException extends CustomException {
+  constructor() {
+    super('U001', '해당 유저를 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
+  }
+}
+
+export class UserInvalidPasswordException extends CustomException {
+  constructor() {
+    super('U002', '비밀번호를 다시 확인해주세요.', HttpStatus.BAD_REQUEST);
+  }
+}
+
+export class UserNicknameDuplicatedException extends CustomException {
+  constructor() {
+    super('U003', '해당 nickname는 사용 중입니다.', HttpStatus.CONFLICT);
+  }
+}
+
+export class UserEmailDuplicatedException extends CustomException {
+  constructor() {
+    super('U004', '이미 해당 Email로 회원가입했습니다.', HttpStatus.CONFLICT);
+  }
+}
+
+export class UserLoginRequiredException extends CustomException {
+  constructor() {
+    super('U005', '로그인이 필요합니다.', HttpStatus.UNAUTHORIZED);
+  }
+}

--- a/Mindspace_back/src/user/user.controller.ts
+++ b/Mindspace_back/src/user/user.controller.ts
@@ -1,10 +1,19 @@
-import { Controller, Post, Get, Body, HttpStatus, Res } from '@nestjs/common';
-import { UserService } from './user.service';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  HttpStatus,
+  Res,
+  Headers,
+} from '@nestjs/common';
+import { Response } from 'express';
 import { UserMapper } from './dto/user.mapper';
 import { UserSignupRequestDto } from './dto/user-signup-request.dto';
 import { UserLoginRequestDto } from './dto/user-login-request.dto';
-import { Response } from 'express';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { UserNicknameResponseDto } from './dto/user-nickname-response.dto';
+import { UserService } from './user.service';
 
 @ApiTags('User')
 @Controller('api/v1/user')
@@ -43,5 +52,13 @@ export class UserController {
   async getAllUser(@Res() res: Response): Promise<void> {
     const users = await this.userService.getAllUser();
     res.status(HttpStatus.OK).json(users);
+  }
+
+  @ApiOperation({ summary: '닉네임 반환' })
+  @Get('/nickname')
+  async getUserNickname(
+    @Headers('authorization') userId: number,
+  ): Promise<UserNicknameResponseDto> {
+    return this.userService.getUserNickname(userId);
   }
 }

--- a/Mindspace_back/src/user/user.service.ts
+++ b/Mindspace_back/src/user/user.service.ts
@@ -1,15 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { UserSignupRequestDto } from './dto/user-signup-request.dto';
 import { UserLoginRequestDto } from './dto/user-login-request.dto';
 import { UserMapper } from './dto/user.mapper';
+import { UserNicknameResponseDto } from './dto/user-nickname-response.dto';
 
 @Injectable()
 export class UserService {
   constructor(
-    @InjectRepository(User) private readonly userRepository: Repository<User>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
     private readonly userMapper: UserMapper,
   ) {}
 
@@ -37,5 +39,18 @@ export class UserService {
 
   async getAllUser(): Promise<User[]> {
     return await this.userRepository.find();
+  }
+
+  async getUserNickname(userId: number): Promise<UserNicknameResponseDto> {
+    const user = await this.isUserExisted(userId);
+    return this.userMapper.nicknameDtoFromEntity(user);
+  }
+
+  async isUserExisted(id: number): Promise<User> {
+    const user = await this.userRepository.findOne({ where: { id: id } });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${id} not found`);
+    }
+    return user;
   }
 }


### PR DESCRIPTION
## Summary
userName 반환 api 및 user 예외처리

## Description
- userName을 반환하는 api
- user 예외처리
```
USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001","해당 유저를 찾을 수 없습니다."),
USER_INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U002","비밀번호를 다시 확인해주세요."),
USER_NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "U003", "해당 nickname는 사용 중입니다." ),
USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "U004", "이미 해당 Email로 회원가입했습니다." ),
``` 

## Screenshots
<img width="1088" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/2147a051-7be9-4dea-a7c6-6f45be22e9ef">
<img width="1082" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/5dfa054d-8d4c-4633-b95f-df9a5518535f">
<img width="1095" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/2f8abc6a-4811-4cf7-92af-5a8ee02a22f1">
<img width="1094" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/f839a733-8ca3-403c-b02c-2c3232876e90">
<img width="1089" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/d1bb327c-901a-4249-877e-8808dcaf64d0">


## Test Checklist
- [x] U001, U002, U003, U004 예외처리 확인이 가능한 지
- [x] username을 반환하는 api가 정상동작하는지

## 참고
기존처럼 에러 코드만 따로 파일을 만들려고 했는데, 잘 안되서 우선 CustomException만 분리했습니다. 추후 에러 코드만 분리하겠습니다.