### PR TITLE
Feat/#21

### DIFF
--- a/Mindspace_back/package.json
+++ b/Mindspace_back/package.json
@@ -31,7 +31,8 @@
     "date-fns": "^2.30.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.17",
+    "typeorm-cursor-pagination": "^0.10.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/Mindspace_back/package.json
+++ b/Mindspace_back/package.json
@@ -28,6 +28,7 @@
     "@types/bcrypt": "^5.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "date-fns": "^2.30.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17"

--- a/Mindspace_back/pnpm-lock.yaml
+++ b/Mindspace_back/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   class-validator:
     specifier: ^0.14.0
     version: 0.14.0
+  date-fns:
+    specifier: ^2.30.0
+    version: 2.30.0
   reflect-metadata:
     specifier: ^0.1.13
     version: 0.1.13

--- a/Mindspace_back/pnpm-lock.yaml
+++ b/Mindspace_back/pnpm-lock.yaml
@@ -41,6 +41,9 @@ dependencies:
   typeorm:
     specifier: ^0.3.17
     version: 0.3.17(pg@8.11.3)(ts-node@10.9.1)
+  typeorm-cursor-pagination:
+    specifier: ^0.10.1
+    version: 0.10.1(typeorm@0.3.17)
 
 devDependencies:
   '@nestjs/cli':
@@ -5131,6 +5134,14 @@ packages:
 
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  /typeorm-cursor-pagination@0.10.1(typeorm@0.3.17):
+    resolution: {integrity: sha512-ezMx9giREI8aBVUpOs7RPn5/uIdygqlduuXJcKiny9UnUXev3zIJaoXCHlrenT6pgcR1cx3baHG/HImPEgeVgA==}
+    peerDependencies:
+      typeorm: ^0.3.6
+    dependencies:
+      typeorm: 0.3.17(pg@8.11.3)(ts-node@10.9.1)
+    dev: false
 
   /typeorm@0.3.17(pg@8.11.3)(ts-node@10.9.1):
     resolution: {integrity: sha512-UDjUEwIQalO9tWw9O2A4GU+sT3oyoUXheHJy4ft+RFdnRdQctdQ34L9SqE2p7LdwzafHx1maxT+bqXON+Qnmig==}

--- a/Mindspace_back/src/app.module.ts
+++ b/Mindspace_back/src/app.module.ts
@@ -50,7 +50,6 @@ export class LoggerMiddleware implements NestMiddleware {
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
       entities: [Node, User, Board, Comment, CustomCommentRepository],
-      synchronize: true, // 개발 환경에서만 true로 설정
     }),
     Neo4jModule.forRoot({
       scheme: 'neo4j',

--- a/Mindspace_back/src/app.module.ts
+++ b/Mindspace_back/src/app.module.ts
@@ -18,6 +18,7 @@ import { Board } from './board/entities/board.entity';
 import { BoardModule } from './board/board.module';
 import { CommentModule } from './comment/comment.module';
 import { Comment } from './comment/entities/comment.entity';
+import { CustomCommentRepository } from './comment/repository/comment.repository';
 
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {
@@ -48,7 +49,7 @@ export class LoggerMiddleware implements NestMiddleware {
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
-      entities: [Node, User, Board, Comment],
+      entities: [Node, User, Board, Comment, CustomCommentRepository],
       synchronize: true, // 개발 환경에서만 true로 설정
     }),
     Neo4jModule.forRoot({

--- a/Mindspace_back/src/app.module.ts
+++ b/Mindspace_back/src/app.module.ts
@@ -16,10 +16,13 @@ import { UserModule } from './user/user.module';
 import { User } from './user/entities/user.entity';
 import { Board } from './board/entities/board.entity';
 import { BoardModule } from './board/board.module';
+import { CommentModule } from './comment/comment.module';
+import { Comment } from './comment/entities/comment.entity';
 
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {
   private logger = new Logger('HTTP');
+
   use(req: Request, res: Response, next: NextFunction) {
     const { method, originalUrl } = req;
     const userAgent = req.get('user-agent') || '';
@@ -45,7 +48,7 @@ export class LoggerMiddleware implements NestMiddleware {
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_DATABASE,
-      entities: [Node, User, Board],
+      entities: [Node, User, Board, Comment],
       synchronize: true, // 개발 환경에서만 true로 설정
     }),
     Neo4jModule.forRoot({
@@ -58,6 +61,7 @@ export class LoggerMiddleware implements NestMiddleware {
     NodeModule,
     UserModule,
     BoardModule,
+    CommentModule,
   ],
   controllers: [],
   providers: [],

--- a/Mindspace_back/src/board/board.controller.ts
+++ b/Mindspace_back/src/board/board.controller.ts
@@ -31,7 +31,12 @@ export class BoardController {
   constructor(private readonly boardService: BoardService) {}
 
   @ApiOperation({ summary: '노드별 모든 게시글 조회' })
-  @ApiQuery({name: 'node_id', description: '조회하려는 노드의 ID', required: true, type: Number,})
+  @ApiQuery({
+    name: 'node_id',
+    description: '조회하려는 노드의 ID',
+    required: true,
+    type: Number,
+  })
   @Get()
   async getAllBoardsByNodeId(
     @Query('node_id') nodeId: number,
@@ -81,8 +86,17 @@ export class BoardController {
   }
 
   @ApiOperation({ summary: '특정 노드의 사용자 게시글 조회' })
-  @ApiQuery({name: 'node_id', description: '조회하려는 노드의 ID', required: true, type: Number,})
-  @ApiHeader({ name: 'Authorization', description: '사용자 ID', required: true })
+  @ApiQuery({
+    name: 'node_id',
+    description: '조회하려는 노드의 ID',
+    required: true,
+    type: Number,
+  })
+  @ApiHeader({
+    name: 'Authorization',
+    description: '사용자 ID',
+    required: true,
+  })
   @ApiResponse({
     status: 200,
     description: '게시글 조회 성공',

--- a/Mindspace_back/src/board/board.controller.ts
+++ b/Mindspace_back/src/board/board.controller.ts
@@ -45,14 +45,14 @@ export class BoardController {
   }
 
   @ApiOperation({ summary: '게시글 생성' })
-  @ApiQuery({ name: 'node_id', description: '게시글을 작성할 노드의 ID' })
-  @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
+  @ApiQuery({ name: 'node_id', description: '게시글을 작성할 노드의 ID'})
+  @ApiHeader({ name: 'user_id', description: '사용자 ID'})
   @ApiResponse({ status: 201, description: '게시글 작성 성공', type: Board }) // 201 Created response
   @ApiResponse({ status: 500, description: '서버 오류' }) // 500 Internal Server Error response
   @Post()
   async createBoard(
     @Query('node_id') nodeId: number,
-    @Headers('Authorization') userIdHeader: string,
+    @Headers('user_id') userIdHeader: string,
     @Body() createBoardDto: CreateBoardDto,
   ): Promise<BoardResponseDto> {
     // <-- 변경된 반환 타입
@@ -62,13 +62,13 @@ export class BoardController {
 
   @ApiOperation({ summary: '게시글 수정' })
   @ApiQuery({ name: 'node_id', description: '게시글을 작성할 노드의 ID' })
-  @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
+  @ApiHeader({ name: 'user_id', description: '사용자 ID' })
   @ApiResponse({ status: 201, description: '게시글 작성 성공', type: Board }) // 201 Created response
   @ApiResponse({ status: 500, description: '서버 오류' }) // 500 Internal Server Error response
   @Put()
   async updateBoard(
     @Query('node_id') nodeId: number,
-    @Headers('Authorization') userIdHeader: string,
+    @Headers('user_id') userIdHeader: string,
     @Body() updateBoardDto: UpdateBoardDto,
   ): Promise<BoardResponseDto> {
     // <-- 변경된 반환 타입
@@ -80,7 +80,7 @@ export class BoardController {
   @Delete()
   async deleteOwnBoard(
     @Query('node_id') nodeId: number,
-    @Headers('Authorization') userId: string,
+    @Headers('user_id') userId: string,
   ) {
     return this.boardService.deleteOwnBoard(nodeId, userId);
   }
@@ -93,7 +93,7 @@ export class BoardController {
     type: Number,
   })
   @ApiHeader({
-    name: 'Authorization',
+    name: 'user_id',
     description: '사용자 ID',
     required: true,
   })
@@ -106,7 +106,7 @@ export class BoardController {
   @Get()
   async getBoardByNodeId(
     @Query('node_id') nodeId: number,
-    @Headers('Authorization') userIdHeader: string,
+    @Headers('user_id') userIdHeader: string,
   ): Promise<SpecificBoardNodeDto> {
     const userId = parseInt(userIdHeader);
     return await this.boardService.getBoardByNodeIdAndUserId(nodeId, userId);

--- a/Mindspace_back/src/board/board.controller.ts
+++ b/Mindspace_back/src/board/board.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Delete,
@@ -45,8 +46,8 @@ export class BoardController {
   }
 
   @ApiOperation({ summary: '게시글 생성' })
-  @ApiQuery({ name: 'node_id', description: '게시글을 작성할 노드의 ID'})
-  @ApiHeader({ name: 'user_id', description: '사용자 ID'})
+  @ApiQuery({ name: 'node_id', description: '게시글을 작성할 노드의 ID' })
+  @ApiHeader({ name: 'user_id', description: '사용자 ID' })
   @ApiResponse({ status: 201, description: '게시글 작성 성공', type: Board }) // 201 Created response
   @ApiResponse({ status: 500, description: '서버 오류' }) // 500 Internal Server Error response
   @Post()
@@ -77,11 +78,16 @@ export class BoardController {
   }
 
   @ApiOperation({ summary: '게시글 삭제' })
+  @ApiQuery({ name: 'node_id', description: '게시글을 삭제할 노드의 ID' })
+  @ApiHeader({ name: 'user_id', description: '사용자 ID' })
+  @ApiResponse({ status: 201, description: '게시글 삭제 성공', type: Board }) // 201 Created response
+  @ApiResponse({ status: 500, description: '서버 오류' }) // 500 Internal Server Error response
   @Delete()
   async deleteOwnBoard(
     @Query('node_id') nodeId: number,
-    @Headers('user_id') userId: string,
+    @Headers('user_id') userIdHeader: string,
   ) {
+    const userId = userIdHeader; // 문자열로 변환
     return this.boardService.deleteOwnBoard(nodeId, userId);
   }
 

--- a/Mindspace_back/src/board/board.module.ts
+++ b/Mindspace_back/src/board/board.module.ts
@@ -13,5 +13,6 @@ import { UserModule } from '../user/user.module'; // Corrected this import to Bo
   ],
   providers: [BoardService, BoardMapper],
   controllers: [BoardController],
+  exports: [BoardService],
 })
 export class BoardModule {}

--- a/Mindspace_back/src/board/board.service.ts
+++ b/Mindspace_back/src/board/board.service.ts
@@ -129,4 +129,14 @@ export class BoardService {
     }
     return BoardMapper.toBoardDetailDto(board);
   }
+
+  async findBoardById(boardId: number): Promise<Board> {
+    const board = await this.boardRepository.findOne({
+      where: { id: boardId },
+    });
+    if (!board) {
+      throw new Error('Board not found');
+    }
+    return board;
+  }
 }

--- a/Mindspace_back/src/board/board.service.ts
+++ b/Mindspace_back/src/board/board.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   NotFoundException,
   UnauthorizedException,
@@ -91,20 +92,24 @@ export class BoardService {
 
   async deleteOwnBoard(nodeId: number, userId: string): Promise<void> {
     const convertedUserId = parseInt(userId); // userId를 숫자로 변환
+    if (isNaN(convertedUserId)) {
+      throw new BadRequestException('Invalid user ID.');
+    }
 
     const board = await this.boardRepository.findOne({
-      where: { id: nodeId, userId: convertedUserId },
+      where: { nodeId: nodeId, userId: convertedUserId },
     });
 
     if (!board) {
-      throw new NotFoundException(`게시물 ${nodeId}를 찾을 수 없습니다.`);
+      throw new NotFoundException(
+        `${nodeId}에 작성된 게시물을 찾을 수 없습니다.`,
+      );
     }
 
-    if (board.userId !== convertedUserId) {
-      throw new UnauthorizedException(`게시물을 삭제할 권한이 없습니다.`);
-    }
-
-    await this.boardRepository.delete(nodeId);
+    await this.boardRepository.delete({
+      nodeId: nodeId,
+      userId: convertedUserId,
+    });
   }
 
   async getBoardByNodeIdAndUserId(

--- a/Mindspace_back/src/board/board.service.ts
+++ b/Mindspace_back/src/board/board.service.ts
@@ -135,7 +135,7 @@ export class BoardService {
       where: { id: boardId },
     });
     if (!board) {
-      throw new Error('Board not found');
+      throw new Error(`Board with ID ${boardId} not found`);
     }
     return board;
   }

--- a/Mindspace_back/src/board/entities/board.entity.ts
+++ b/Mindspace_back/src/board/entities/board.entity.ts
@@ -7,14 +7,18 @@ import {
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { User } from '../../user/entities/user.entity';
-import { Timestamp } from '../../global/common/timeStamp'; // User 엔터티 임포트
-// swagger에서 본문 바디 얘사에 안 나오게 하고 싶으면 @ApiProperty를 지우면 안나옴
+import { Timestamp } from '../../global/common/timeStamp';
+import { Node } from '../../node/entities/node.entity';
 
 @Entity('boards')
 export class Board extends Timestamp {
   @PrimaryGeneratedColumn('increment', { name: 'board_id' })
   @ApiProperty({ description: '게시글의 ID.' })
   id: number;
+
+  @ManyToOne(() => Node)
+  @JoinColumn({ name: 'node_id' })
+  node: Node;
 
   @Column({ name: 'node_id', type: 'int', nullable: false })
   nodeId: number;

--- a/Mindspace_back/src/comment/comment.controller.spec.ts
+++ b/Mindspace_back/src/comment/comment.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentController } from './comment.controller';
+
+describe('CommentController', () => {
+  let controller: CommentController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommentController],
+    }).compile();
+
+    controller = module.get<CommentController>(CommentController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -10,6 +10,7 @@ import {
 import { CommentService } from './comment.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { ApiHeader, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { CommentResponseDto } from './dto/comment-response.dto';
 
 @ApiTags('Comment')
 @Controller('api/v1/comments')
@@ -26,5 +27,13 @@ export class CommentController {
   ): Promise<CreateCommentDto> {
     const userId = userIdHeader; // 문자열로 변환
     return this.commentService.createComment(boardId, userId, createCommentDto);
+  }
+
+  @ApiQuery({ name: 'board_id', description: '댓글을 조회할 게시글의 ID' })
+  @Get()
+  async getComments(
+    @Query('board_id') boardId: number,
+  ): Promise<CommentResponseDto[]> {
+    return await this.commentService.getCommentsByBoardId(boardId);
   }
 }

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -21,11 +21,10 @@ export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
   @ApiOperation({ summary: '댓글 생성' })
-  @ApiQuery({ name: 'board_id', description: '댓글을 작성할 노드의 ID' })
   @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
-  @Post()
+  @Post(':boardId')
   async createComment(
-    @Query('board_id') boardId: number,
+    @Param('boardId') boardId: number,
     @Headers('Authorization') userIdHeader: string,
     @Body() createCommentDto: CreateCommentDto,
   ): Promise<CreateCommentDto> {
@@ -34,10 +33,9 @@ export class CommentController {
   }
 
   @ApiOperation({ summary: '댓글 조회' })
-  @ApiQuery({ name: 'board_id', description: '댓글을 조회할 게시글의 ID' })
-  @Get()
+  @Get(':boardId')
   async getComments(
-    @Query('board_id') boardId: number,
+    @Param('boardId') boardId: number,
   ): Promise<CommentResponseDto[]> {
     return await this.commentService.getCommentsByBoardId(boardId);
   }

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -8,6 +8,8 @@ import {
   Headers,
   Put,
   Delete,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
@@ -30,13 +32,16 @@ export class CommentController {
   @ApiQuery({ name: 'board_id', description: '댓글을 작성할 게시글의 ID' })
   @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
   @Post()
+  @HttpCode(HttpStatus.CREATED)
   async createComment(
     @Param('board_id') boardId: number,
     @Headers('Authorization') userIdHeader: string,
     @Body() createCommentDto: CreateCommentDto,
-  ): Promise<CreateCommentDto> {
-    const userId = userIdHeader; // 문자열로 변환
-    return this.commentService.createComment(boardId, userId, createCommentDto);
+  ): Promise<{ message: string }> {
+    const userId = userIdHeader;
+    await this.commentService.createComment(boardId, userId, createCommentDto);
+
+    return { message: '댓글이 성공적으로 작성되었습니다.' };
   }
 
   @ApiOperation({ summary: '댓글 조회' })

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -7,10 +7,11 @@ import {
   Query,
   Headers,
   Put,
+  Delete,
 } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
-import { ApiHeader, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiHeader, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { CommentResponseDto } from './dto/comment-response.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 
@@ -19,6 +20,7 @@ import { UpdateCommentDto } from './dto/update-comment.dto';
 export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
+  @ApiOperation({ summary: '댓글 생성' })
   @ApiQuery({ name: 'board_id', description: '댓글을 작성할 노드의 ID' })
   @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
   @Post()
@@ -31,6 +33,7 @@ export class CommentController {
     return this.commentService.createComment(boardId, userId, createCommentDto);
   }
 
+  @ApiOperation({ summary: '댓글 조회' })
   @ApiQuery({ name: 'board_id', description: '댓글을 조회할 게시글의 ID' })
   @Get()
   async getComments(
@@ -39,11 +42,18 @@ export class CommentController {
     return await this.commentService.getCommentsByBoardId(boardId);
   }
 
+  @ApiOperation({ summary: '댓글 수정' })
   @Put(':commentId')
   async updateComment(
     @Param('commentId') commentId: number,
     @Body() updateCommentDto: UpdateCommentDto,
   ): Promise<UpdateCommentDto> {
     return await this.commentService.updateComment(commentId, updateCommentDto);
+  }
+
+  @ApiOperation({ summary: '댓글 삭제' })
+  @Delete(':commentId')
+  async deleteComment(@Param('commentId') commentId: number): Promise<void> {
+    return await this.commentService.deleteComment(commentId);
   }
 }

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -6,11 +6,13 @@ import {
   Param,
   Query,
   Headers,
+  Put,
 } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
-import { ApiHeader, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ApiHeader, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CommentResponseDto } from './dto/comment-response.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
 
 @ApiTags('Comment')
 @Controller('api/v1/comments')
@@ -35,5 +37,13 @@ export class CommentController {
     @Query('board_id') boardId: number,
   ): Promise<CommentResponseDto[]> {
     return await this.commentService.getCommentsByBoardId(boardId);
+  }
+
+  @Put(':commentId')
+  async updateComment(
+    @Param('commentId') commentId: number,
+    @Body() updateCommentDto: UpdateCommentDto,
+  ): Promise<UpdateCommentDto> {
+    return await this.commentService.updateComment(commentId, updateCommentDto);
   }
 }

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -33,12 +33,12 @@ export class CommentController {
 
   @ApiOperation({ summary: '댓글 생성' })
   @ApiQuery({ name: 'board_id', description: '댓글을 작성할 게시글의 ID' })
-  @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
+  @ApiHeader({ name: 'user_id', description: '사용자 ID' })
   @Post()
   @HttpCode(HttpStatus.CREATED)
   async createComment(
     @Query('board_id') boardId: number,
-    @Headers('Authorization') userIdHeader: string,
+    @Headers('user_id') userIdHeader: string,
     @Body() createCommentDto: CreateCommentDto,
   ): Promise<{ message: string }> {
     const userId = userIdHeader;

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -11,7 +11,13 @@ import {
 } from '@nestjs/common';
 import { CommentService } from './comment.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
-import { ApiHeader, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import {
+  ApiHeader,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import { CommentResponseDto } from './dto/comment-response.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 
@@ -21,6 +27,11 @@ export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
   @ApiOperation({ summary: '댓글 생성' })
+  @ApiParam({
+    name: 'boardId',
+    type: 'number',
+    description: '게시판의 ID',
+  })
   @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
   @Post(':boardId')
   async createComment(
@@ -33,14 +44,42 @@ export class CommentController {
   }
 
   @ApiOperation({ summary: '댓글 조회' })
+  @ApiQuery({
+    name: 'page',
+    required: false,
+    type: Number,
+    description: '페이지 번호(기본값: 1)',
+  })
+  @ApiQuery({
+    name: 'pageSize',
+    required: false,
+    type: Number,
+    description: '페이지 당 댓글 수(기본값: 10)',
+  })
+  @ApiParam({
+    name: 'boardId',
+    type: 'number',
+    description: '게시판의 ID',
+  })
   @Get(':boardId')
   async getComments(
     @Param('boardId') boardId: number,
+    @Query('page') page = 1,
+    @Query('pageSize') pageSize = 10,
   ): Promise<CommentResponseDto[]> {
-    return await this.commentService.getCommentsByBoardId(boardId);
+    return await this.commentService.getCommentsByBoardId(
+      boardId,
+      page,
+      pageSize,
+    );
   }
 
   @ApiOperation({ summary: '댓글 수정' })
+  @ApiParam({
+    name: 'commentId',
+    type: 'number',
+    description: '게시글의 ID',
+  })
   @Put(':commentId')
   async updateComment(
     @Param('commentId') commentId: number,
@@ -50,6 +89,11 @@ export class CommentController {
   }
 
   @ApiOperation({ summary: '댓글 삭제' })
+  @ApiParam({
+    name: 'commentId',
+    type: 'number',
+    description: '게시글의 ID',
+  })
   @Delete(':commentId')
   async deleteComment(@Param('commentId') commentId: number): Promise<void> {
     return await this.commentService.deleteComment(commentId);

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -1,0 +1,30 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  Headers,
+} from '@nestjs/common';
+import { CommentService } from './comment.service';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { ApiHeader, ApiQuery, ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Comment')
+@Controller('api/v1/comments')
+export class CommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @ApiQuery({ name: 'board_id', description: '댓글을 작성할 노드의 ID' })
+  @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
+  @Post()
+  async createComment(
+    @Query('board_id') boardId: number,
+    @Headers('Authorization') userIdHeader: string,
+    @Body() createCommentDto: CreateCommentDto,
+  ): Promise<CreateCommentDto> {
+    const userId = userIdHeader; // 문자열로 변환
+    return this.commentService.createComment(boardId, userId, createCommentDto);
+  }
+}

--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -27,15 +27,11 @@ export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
   @ApiOperation({ summary: '댓글 생성' })
-  @ApiParam({
-    name: 'boardId',
-    type: 'number',
-    description: '게시판의 ID',
-  })
+  @ApiQuery({ name: 'board_id', description: '댓글을 작성할 게시글의 ID' })
   @ApiHeader({ name: 'Authorization', description: '사용자 ID' })
-  @Post(':boardId')
+  @Post()
   async createComment(
-    @Param('boardId') boardId: number,
+    @Param('board_id') boardId: number,
     @Headers('Authorization') userIdHeader: string,
     @Body() createCommentDto: CreateCommentDto,
   ): Promise<CreateCommentDto> {
@@ -44,6 +40,7 @@ export class CommentController {
   }
 
   @ApiOperation({ summary: '댓글 조회' })
+  @ApiQuery({ name: 'board_id', description: '댓글을 조회할 게시글의 ID' })
   @ApiQuery({
     name: 'page',
     required: false,
@@ -56,14 +53,9 @@ export class CommentController {
     type: Number,
     description: '페이지 당 댓글 수(기본값: 10)',
   })
-  @ApiParam({
-    name: 'boardId',
-    type: 'number',
-    description: '게시판의 ID',
-  })
-  @Get(':boardId')
+  @Get()
   async getComments(
-    @Param('boardId') boardId: number,
+    @Param('board_id') boardId: number,
     @Query('page') page = 1,
     @Query('pageSize') pageSize = 10,
   ): Promise<CommentResponseDto[]> {

--- a/Mindspace_back/src/comment/comment.module.ts
+++ b/Mindspace_back/src/comment/comment.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { CommentController } from './comment.controller';
+import { CommentService } from './comment.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Comment } from './entities/comment.entity';
+import { CommentMapper } from './dto/comment.mapper.dto';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Comment]), UserModule],
+  providers: [CommentService, CommentMapper],
+  controllers: [CommentController],
+})
+export class CommentModule {}

--- a/Mindspace_back/src/comment/comment.module.ts
+++ b/Mindspace_back/src/comment/comment.module.ts
@@ -5,9 +5,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Comment } from './entities/comment.entity';
 import { CommentMapper } from './dto/comment.mapper.dto';
 import { UserModule } from '../user/user.module';
+import { BoardModule } from '../board/board.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Comment]), UserModule],
+  imports: [TypeOrmModule.forFeature([Comment]), UserModule, BoardModule],
   providers: [CommentService, CommentMapper],
   controllers: [CommentController],
 })

--- a/Mindspace_back/src/comment/comment.module.ts
+++ b/Mindspace_back/src/comment/comment.module.ts
@@ -6,10 +6,11 @@ import { Comment } from './entities/comment.entity';
 import { CommentMapper } from './dto/comment.mapper.dto';
 import { UserModule } from '../user/user.module';
 import { BoardModule } from '../board/board.module';
+import { CustomCommentRepository } from './repository/comment.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Comment]), UserModule, BoardModule],
-  providers: [CommentService, CommentMapper],
+  providers: [CommentService, CommentMapper, CustomCommentRepository],
   controllers: [CommentController],
 })
 export class CommentModule {}

--- a/Mindspace_back/src/comment/comment.service.spec.ts
+++ b/Mindspace_back/src/comment/comment.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentService } from './comment.service';
+
+describe('CommentService', () => {
+  let service: CommentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommentService],
+    }).compile();
+
+    service = module.get<CommentService>(CommentService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/Mindspace_back/src/comment/comment.service.ts
+++ b/Mindspace_back/src/comment/comment.service.ts
@@ -34,8 +34,16 @@ export class CommentService {
     return await this.commentRepository.save(comment);
   }
 
-  async getCommentsByBoardId(boardId: number): Promise<CommentResponseDto[]> {
-    const comments = await this.commentRepository.find({ where: { boardId } });
+  async getCommentsByBoardId(
+    boardId: number,
+    page: number,
+    pageSize: number,
+  ): Promise<CommentResponseDto[]> {
+    const comments = await this.commentRepository.find({
+      where: { boardId },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    });
     return comments.map((comment) =>
       CommentMapper.commentToResponseDto(comment),
     );

--- a/Mindspace_back/src/comment/comment.service.ts
+++ b/Mindspace_back/src/comment/comment.service.ts
@@ -54,4 +54,14 @@ export class CommentService {
     comment.content = updateCommentDto.content;
     return await this.commentRepository.save(comment);
   }
+
+  async deleteComment(comment_id: number): Promise<void> {
+    const comment = await this.commentRepository.findOne({
+      where: { id: comment_id },
+    });
+    if (!comment) {
+      throw new Error('댓글을 찾을 수 없습니다.');
+    }
+    await this.commentRepository.remove(comment);
+  }
 }

--- a/Mindspace_back/src/comment/comment.service.ts
+++ b/Mindspace_back/src/comment/comment.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Comment } from './entities/comment.entity';
+import { CreateCommentDto } from './dto/create-comment.dto';
+import { UserService } from '../user/user.service';
+import { CommentMapper } from './dto/comment.mapper.dto';
+
+@Injectable()
+export class CommentService {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly commentRepository: Repository<Comment>,
+    private readonly commentMapper: CommentMapper,
+    private readonly userService: UserService,
+  ) {}
+
+  async createComment(
+    boardId: number,
+    userId: string,
+    createCommentDto: CreateCommentDto,
+  ): Promise<Comment> {
+    const convertedUserId = Number(userId);
+    const user = await this.userService.findUserById(convertedUserId);
+    const userNickname = user.nickname;
+    const comment = this.commentMapper.dtoToEntity(
+      createCommentDto,
+      boardId,
+      convertedUserId,
+      userNickname,
+    );
+    return await this.commentRepository.save(comment);
+  }
+}

--- a/Mindspace_back/src/comment/comment.service.ts
+++ b/Mindspace_back/src/comment/comment.service.ts
@@ -5,6 +5,7 @@ import { Comment } from './entities/comment.entity';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UserService } from '../user/user.service';
 import { CommentMapper } from './dto/comment.mapper.dto';
+import { CommentResponseDto } from './dto/comment-response.dto';
 
 @Injectable()
 export class CommentService {
@@ -23,12 +24,19 @@ export class CommentService {
     const convertedUserId = Number(userId);
     const user = await this.userService.findUserById(convertedUserId);
     const userNickname = user.nickname;
-    const comment = this.commentMapper.dtoToEntity(
+    const comment = this.commentMapper.DtoToEntity(
       createCommentDto,
       boardId,
       convertedUserId,
       userNickname,
     );
     return await this.commentRepository.save(comment);
+  }
+
+  async getCommentsByBoardId(boardId: number): Promise<CommentResponseDto[]> {
+    const comments = await this.commentRepository.find({ where: { boardId } });
+    return comments.map((comment) =>
+      CommentMapper.commentToResponseDto(comment),
+    );
   }
 }

--- a/Mindspace_back/src/comment/comment.service.ts
+++ b/Mindspace_back/src/comment/comment.service.ts
@@ -6,6 +6,7 @@ import { CreateCommentDto } from './dto/create-comment.dto';
 import { UserService } from '../user/user.service';
 import { CommentMapper } from './dto/comment.mapper.dto';
 import { CommentResponseDto } from './dto/comment-response.dto';
+import { UpdateCommentDto } from './dto/update-comment.dto';
 
 @Injectable()
 export class CommentService {
@@ -38,5 +39,19 @@ export class CommentService {
     return comments.map((comment) =>
       CommentMapper.commentToResponseDto(comment),
     );
+  }
+
+  async updateComment(
+    comment_id: number,
+    updateCommentDto: UpdateCommentDto,
+  ): Promise<UpdateCommentDto> {
+    const comment = await this.commentRepository.findOne({
+      where: { id: comment_id },
+    });
+    if (!comment) {
+      throw new Error('댓글을 찾을 수 없습니다.');
+    }
+    comment.content = updateCommentDto.content;
+    return await this.commentRepository.save(comment);
   }
 }

--- a/Mindspace_back/src/comment/dto/comment-pagination-response.dto.ts
+++ b/Mindspace_back/src/comment/dto/comment-pagination-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CommentResponseDto } from './comment-response.dto';
+
+class Cursor {
+  @ApiProperty({ example: 10 })
+  count: number;
+
+  @ApiProperty({ example: 'Y3JlYXRlZEF0OjE2OTYzMTg5OTc5Mzg' })
+  afterCursor: string | null;
+
+  @ApiProperty({ example: null })
+  beforeCursor: string | null;
+}
+
+export class PaginatedCommentResponseDto {
+  @ApiProperty({ type: [CommentResponseDto] })
+  data: CommentResponseDto[];
+
+  @ApiProperty({ type: Cursor })
+  cursor: Cursor;
+}

--- a/Mindspace_back/src/comment/dto/comment-response.dto.ts
+++ b/Mindspace_back/src/comment/dto/comment-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CommentResponseDto {
+  @ApiProperty({ description: '댓글의 ID' })
+  id: number;
+
+  @ApiProperty({ description: '댓글을 작성한 사용자의 닉네임' })
+  userNickname: string;
+
+  @ApiProperty({ description: '댓글의 내용' })
+  content: string;
+
+  @ApiProperty({ description: '댓글의 마지막 업데이트 시간' })
+  updatedAt: string;
+}

--- a/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
+++ b/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { CreateCommentDto } from './create-comment.dto';
+import { Comment } from '../entities/comment.entity';
+
+@Injectable()
+export class CommentMapper {
+  dtoToEntity(
+    createCommentDto: CreateCommentDto,
+    boardId: number,
+    userId: number,
+    userNickname: string,
+  ): Comment {
+    const comment = new Comment();
+    comment.content = createCommentDto.content;
+    comment.boardId = boardId;
+    comment.userId = userId;
+    comment.userNickname = userNickname;
+    return comment;
+  }
+}

--- a/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
+++ b/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
@@ -4,19 +4,21 @@ import { ko } from 'date-fns/locale';
 import { CreateCommentDto } from './create-comment.dto';
 import { Comment } from '../entities/comment.entity';
 import { CommentResponseDto } from './comment-response.dto';
+import { User } from '../../user/entities/user.entity';
+import { Board } from '../../board/entities/board.entity';
 
 @Injectable()
 export class CommentMapper {
   DtoToEntity(
     createCommentDto: CreateCommentDto,
-    boardId: number,
-    userId: number,
+    user: User,
+    board: Board,
     userNickname: string,
   ): Comment {
     const comment = new Comment();
     comment.content = createCommentDto.content;
-    comment.boardId = boardId;
-    comment.userId = userId;
+    comment.user = user;
+    comment.board = board;
     comment.userNickname = userNickname;
     return comment;
   }

--- a/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
+++ b/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
@@ -1,10 +1,13 @@
 import { Injectable } from '@nestjs/common';
+import { formatDistanceToNow } from 'date-fns';
+import { ko } from 'date-fns/locale';
 import { CreateCommentDto } from './create-comment.dto';
 import { Comment } from '../entities/comment.entity';
+import { CommentResponseDto } from './comment-response.dto';
 
 @Injectable()
 export class CommentMapper {
-  dtoToEntity(
+  DtoToEntity(
     createCommentDto: CreateCommentDto,
     boardId: number,
     userId: number,
@@ -16,5 +19,17 @@ export class CommentMapper {
     comment.userId = userId;
     comment.userNickname = userNickname;
     return comment;
+  }
+
+  static commentToResponseDto(comment: Comment): CommentResponseDto {
+    return {
+      id: comment.id,
+      userNickname: comment.userNickname,
+      content: comment.content,
+      updatedAt: formatDistanceToNow(comment.updatedAt, {
+        addSuffix: true,
+        locale: ko,
+      }),
+    };
   }
 }

--- a/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
+++ b/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
@@ -19,14 +19,14 @@ export class CommentMapper {
     comment.content = createCommentDto.content;
     comment.user = user;
     comment.board = board;
-    comment.userNickname = userNickname;
+    user.nickname = userNickname;
     return comment;
   }
 
   static commentToResponseDto(comment: Comment): CommentResponseDto {
     return {
       id: comment.id,
-      userNickname: comment.userNickname,
+      userNickname: comment.user.nickname,
       content: comment.content,
       updatedAt: formatDistanceToNow(comment.updatedAt, {
         addSuffix: true,

--- a/Mindspace_back/src/comment/dto/create-comment.dto.ts
+++ b/Mindspace_back/src/comment/dto/create-comment.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty } from 'class-validator';
+
+export class CreateCommentDto {
+  @ApiProperty({ description: '댓글 내용', example: '댓글 작성' })
+  @IsNotEmpty()
+  content: string;
+}

--- a/Mindspace_back/src/comment/dto/update-comment.dto.ts
+++ b/Mindspace_back/src/comment/dto/update-comment.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCommentDto } from './create-comment.dto';
+
+export class UpdateCommentDto extends PartialType(CreateCommentDto) {}

--- a/Mindspace_back/src/comment/entities/comment.entity.ts
+++ b/Mindspace_back/src/comment/entities/comment.entity.ts
@@ -24,10 +24,6 @@ export class Comment extends Timestamp {
   @JoinColumn({ name: 'user_id' }) // 외래 키 컬럼 설정
   user: User; // User 엔터티 타입의 프로퍼티 추가
 
-  @Column({ name: 'user_nickname', type: 'varchar', nullable: false })
-  @ApiProperty({ description: '댓글을 작성한 사용자의 닉네임.' })
-  userNickname: string;
-
   @ManyToOne(() => Board) // Board 엔터티를 참조하는 ManyToOne 관계 설정
   @JoinColumn({ name: 'board_id' }) // 외래 키 컬럼 설정
   board: Board; // Board 엔터티 타입의 프로퍼티 추가

--- a/Mindspace_back/src/comment/entities/comment.entity.ts
+++ b/Mindspace_back/src/comment/entities/comment.entity.ts
@@ -1,0 +1,40 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Timestamp } from '../../global/common/timeStamp';
+import { User } from '../../user/entities/user.entity';
+import { Board } from '../../board/entities/board.entity';
+import { ApiProperty } from '@nestjs/swagger';
+
+@Entity('comment')
+export class Comment extends Timestamp {
+  @PrimaryGeneratedColumn('increment', { name: 'comment_id' })
+  @ApiProperty({ description: '댓글 ID' })
+  id: number;
+
+  @Column({ name: 'content', type: 'varchar', nullable: false })
+  @ApiProperty({ description: '댓글 내용' })
+  content: string;
+
+  @ManyToOne(() => User) // User 엔터티를 참조하는 ManyToOne 관계 설정
+  @JoinColumn({ name: 'user_id' }) // 외래 키 컬럼 설정
+  user: User; // User 엔터티 타입의 프로퍼티 추가
+
+  @Column({ name: 'user_id', type: 'int', nullable: false })
+  userId: number;
+
+  @Column({ name: 'user_nickname', type: 'varchar', nullable: false })
+  @ApiProperty({ description: '댓글을 작성한 사용자의 닉네임.' })
+  userNickname: string;
+
+  @ManyToOne(() => Board) // Board 엔터티를 참조하는 ManyToOne 관계 설정
+  @JoinColumn({ name: 'board_id' }) // 외래 키 컬럼 설정
+  board: Board; // Board 엔터티 타입의 프로퍼티 추가
+
+  @Column({ name: 'board_id', type: 'int', nullable: false })
+  boardId: number;
+}

--- a/Mindspace_back/src/comment/entities/comment.entity.ts
+++ b/Mindspace_back/src/comment/entities/comment.entity.ts
@@ -24,9 +24,6 @@ export class Comment extends Timestamp {
   @JoinColumn({ name: 'user_id' }) // 외래 키 컬럼 설정
   user: User; // User 엔터티 타입의 프로퍼티 추가
 
-  @Column({ name: 'user_id', type: 'int', nullable: false })
-  userId: number;
-
   @Column({ name: 'user_nickname', type: 'varchar', nullable: false })
   @ApiProperty({ description: '댓글을 작성한 사용자의 닉네임.' })
   userNickname: string;
@@ -34,7 +31,4 @@ export class Comment extends Timestamp {
   @ManyToOne(() => Board) // Board 엔터티를 참조하는 ManyToOne 관계 설정
   @JoinColumn({ name: 'board_id' }) // 외래 키 컬럼 설정
   board: Board; // Board 엔터티 타입의 프로퍼티 추가
-
-  @Column({ name: 'board_id', type: 'int', nullable: false })
-  boardId: number;
 }

--- a/Mindspace_back/src/comment/repository/comment.repository.ts
+++ b/Mindspace_back/src/comment/repository/comment.repository.ts
@@ -14,6 +14,7 @@ export class CustomCommentRepository {
 
   async paginate(boardId: number, pagingParams?: PagingParams) {
     const queryBuilder = this.CommentRepository.createQueryBuilder('comment')
+      .innerJoinAndSelect('comment.user', 'user')
       .where('comment.board_id = :boardId', { boardId })
       .orderBy('comment.id', 'DESC');
 

--- a/Mindspace_back/src/comment/repository/comment.repository.ts
+++ b/Mindspace_back/src/comment/repository/comment.repository.ts
@@ -13,7 +13,6 @@ export class CustomCommentRepository {
   ) {}
 
   async paginate(boardId: number, pagingParams?: PagingParams) {
-    // 수정: pagingParams 파라미터 추가
     const queryBuilder = this.CommentRepository.createQueryBuilder('comment')
       .where('comment.board_id = :boardId', { boardId })
       .orderBy('comment.id', 'DESC');
@@ -29,7 +28,7 @@ export class CustomCommentRepository {
       },
     });
 
-    const paginationResult = await paginator.paginate(queryBuilder); // 수정: paginationResult 변수 추가
+    const paginationResult = await paginator.paginate(queryBuilder);
 
     return {
       data: paginationResult.data,

--- a/Mindspace_back/src/comment/repository/comment.repository.ts
+++ b/Mindspace_back/src/comment/repository/comment.repository.ts
@@ -1,0 +1,42 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { buildPaginator } from 'typeorm-cursor-pagination';
+import { PagingParams } from '../../global/common/type';
+import { Comment } from '../entities/comment.entity';
+
+@Injectable()
+export class CustomCommentRepository {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly CommentRepository: Repository<Comment>,
+  ) {}
+
+  async paginate(boardId: number, pagingParams?: PagingParams) {
+    // 수정: pagingParams 파라미터 추가
+    const queryBuilder = this.CommentRepository.createQueryBuilder('comment')
+      .where('comment.board_id = :boardId', { boardId })
+      .orderBy('comment.id', 'DESC');
+
+    const paginator = buildPaginator({
+      entity: Comment,
+      paginationKeys: ['createdAt'],
+      query: {
+        limit: 10,
+        order: 'DESC',
+        afterCursor: pagingParams.afterCursor,
+        beforeCursor: pagingParams.beforeCursor,
+      },
+    });
+
+    const paginationResult = await paginator.paginate(queryBuilder); // 수정: paginationResult 변수 추가
+
+    return {
+      data: paginationResult.data,
+      cursor: {
+        count: paginationResult.data.length,
+        ...paginationResult.cursor,
+      },
+    };
+  }
+}

--- a/Mindspace_back/src/global/common/timeStamp.ts
+++ b/Mindspace_back/src/global/common/timeStamp.ts
@@ -1,4 +1,9 @@
-import { CreateDateColumn, UpdateDateColumn, BaseEntity } from 'typeorm';
+import {
+  BaseEntity,
+  CreateDateColumn,
+  DeleteDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 export abstract class Timestamp extends BaseEntity {
   @CreateDateColumn({ type: 'timestamp' })
@@ -6,4 +11,7 @@ export abstract class Timestamp extends BaseEntity {
 
   @UpdateDateColumn({ type: 'timestamp' })
   updatedAt: Date;
+
+  @DeleteDateColumn({ type: 'timestamp', nullable: true })
+  deletedAt: Date | null;
 }

--- a/Mindspace_back/src/global/common/type.ts
+++ b/Mindspace_back/src/global/common/type.ts
@@ -1,0 +1,5 @@
+export interface PagingParams {
+  afterCursor?: string;
+  beforeCursor?: string;
+  limit?: number;
+}

--- a/Mindspace_back/src/main.ts
+++ b/Mindspace_back/src/main.ts
@@ -23,6 +23,6 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, options);
   SwaggerModule.setup('docs', app, document);
 
-  await app.listen(8080);
+  await app.listen(8000);
 }
 bootstrap();

--- a/Mindspace_back/src/node/entities/node.entity.ts
+++ b/Mindspace_back/src/node/entities/node.entity.ts
@@ -1,13 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { Timestamp } from '../../global/common/timeStamp';
 
 @Entity()
 export class Node extends Timestamp {
+  @PrimaryGeneratedColumn('increment', { name: 'node_id' })
+  id: number;
 
-    @PrimaryGeneratedColumn('increment', { name: 'node_id' })
-    id: number;
-
-    @Column({ name: 'node_name', type: 'varchar', nullable: false })
-    name: string;
-
+  @Column({ name: 'node_name', type: 'varchar', nullable: false })
+  name: string;
 }

--- a/Mindspace_back/src/node/node.controller.ts
+++ b/Mindspace_back/src/node/node.controller.ts
@@ -1,13 +1,16 @@
 import { Controller, Get } from '@nestjs/common';
-import { NodeService } from './node.service'; 
+import { NodeService } from './node.service';
 import { Node } from './entities/node.entity';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Node')
 @Controller('api/v1/node')
 export class NodeController {
-    constructor(private readonly nodeService: NodeService) {}
+  constructor(private readonly nodeService: NodeService) {}
 
-    @Get()
-    async getAllNode(): Promise<Node[]> {
-        return this.nodeService.getAllNode();
-    }
+  @ApiOperation({ summary: '전체 노드 조회' })
+  @Get()
+  async getAllNode(): Promise<Node[]> {
+    return this.nodeService.getAllNode();
+  }
 }

--- a/Mindspace_back/src/node/node.module.ts
+++ b/Mindspace_back/src/node/node.module.ts
@@ -1,12 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { Node } from './entities/node.entity'; 
-import { NodeController } from './node.controller'; 
-import { NodeService } from './node.service'; 
+import { Node } from './entities/node.entity';
+import { NodeController } from './node.controller';
+import { NodeService } from './node.service';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Node])],
-    controllers: [NodeController],
-    providers: [NodeService],
+  imports: [TypeOrmModule.forFeature([Node])],
+  controllers: [NodeController],
+  providers: [NodeService],
 })
 export class NodeModule {}

--- a/Mindspace_back/src/node/node.service.ts
+++ b/Mindspace_back/src/node/node.service.ts
@@ -5,9 +5,11 @@ import { Node } from './entities/node.entity';
 
 @Injectable()
 export class NodeService {
-    constructor(@InjectRepository(Node) private readonly nodeRepository: Repository<Node>) {}
+  constructor(
+    @InjectRepository(Node) private readonly nodeRepository: Repository<Node>,
+  ) {}
 
-    async getAllNode(): Promise<Node[]> {
-        return this.nodeRepository.find();
-    }
+  async getAllNode(): Promise<Node[]> {
+    return this.nodeRepository.find();
+  }
 }

--- a/Mindspace_back/src/user/user.module.ts
+++ b/Mindspace_back/src/user/user.module.ts
@@ -8,8 +8,8 @@ import { UserMapper } from './dto/user.mapper';
 // user.module.ts
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
-  providers: [UserService, UserMapper], // UserService가 여기에 포함되어 있어야 합니다.
+  providers: [UserService, UserMapper],
   controllers: [UserController],
-  exports: [UserService], // UserService를 내보내야 합니다.
+  exports: [UserService],
 })
 export class UserModule {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     environment:
       - TZ=Asia/Seoul
     ports:
-      - '8080:8080'
+      - '8000:8000'
     depends_on:
       - db
       - neo4j

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       context: ./Mindspace_back
       dockerfile: Dockerfile
     restart: always
+    environment:
+      - TZ=Asia/Seoul
     ports:
       - '8080:8080'
     depends_on:


### PR DESCRIPTION
## Summary
게시글 작성 API 구현

## Description
- 게시글 dto, entity, service, module 생성
- 게시글 조회 시 페이지네이션 기능 구현
- API 명세서 노션 링크 : https://www.notion.so/dr0joon/Comment-e1afd45acc1c41acb3aaa0cdbee16ba2?pvs=4

## Screenshots
<img width="1090" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/b53ee1bd-305e-42e0-bace-264755f5e639">
<img width="1099" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/c7f04681-5fbe-4b1c-92dc-8ae8fc4b2932">
<img width="1090" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/f2af9391-9add-4359-8678-1dc4a630507d">
<img width="1100" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/83844c46-07f1-47b0-bf1c-a17291f4af22">

## 참고
추가로 설치한 라이브러리가 존재하므로 Mindspace_back 폴더 경로에서 `pnpm i `후 실행 부탁드립니다.

## Test Checklist
- [x] 댓글 작성, 조회, 수정, 삭제 API가 정상적으로 작동하는 지