### PR TITLE
fix/#31

### DIFF
--- a/Mindspace_back/src/comment/entities/comment.entity.ts
+++ b/Mindspace_back/src/comment/entities/comment.entity.ts
@@ -24,7 +24,7 @@ export class Comment extends Timestamp {
   @JoinColumn({ name: 'user_id' }) // 외래 키 컬럼 설정
   user: User; // User 엔터티 타입의 프로퍼티 추가
 
-  @ManyToOne(() => Board) // Board 엔터티를 참조하는 ManyToOne 관계 설정
+  @ManyToOne(() => Board, { onDelete: 'CASCADE' }) // Board 엔터티를 참조하는 ManyToOne 관계 설정, 외래키 제약 조건 수정
   @JoinColumn({ name: 'board_id' }) // 외래 키 컬럼 설정
   board: Board; // Board 엔터티 타입의 프로퍼티 추가
 }


### PR DESCRIPTION
## Summary
게시글을 삭제할 때 댓글이 있으면 삭제가 안되는 문제 해결

## Description
- TypeORM으로 모델을 수정하여 외래 키 옵션을 변경했습니다.
- board가 삭제될 때 연결된 comment도 같이 삭제되도록 진행했습니다.

## Screenshots
게시글을 생성하고, 해당 게시글에 댓글이 1개 이상 생성되어있다는 가정 하에 진행합니다.
<img width="1139" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/105929978/e78f3f19-fd50-45d9-b9c6-b28af386d10d">


## Test Checklist
- [x] 게시글을 생성하고 해당 게시글에 댓글을 1개 이상 달고 해당 게시글을 삭제했을 때 게시글과 댓글이 전부 정상적으로 삭제되는 지 확인해주세요.