### PR TITLE
Feat/#51 - ImageUpload UI & 기능구현

### DIFF
--- a/Mindspace_front_next/app/api/board.ts
+++ b/Mindspace_front_next/app/api/board.ts
@@ -1,6 +1,6 @@
 import { csrFetch } from "./utils/csrFetch";
-import { CreatePostRequest } from "@/constants/types";
-export const getPost = async (id: number) => {
+import { CreateBoardRequest } from "@/constants/types";
+export const getBoard = async (id: number) => {
   const endpoint = `boards?node_id=${id}`;
 
   const data = await csrFetch(endpoint, {
@@ -10,7 +10,7 @@ export const getPost = async (id: number) => {
   return data;
 };
 
-export const deletePost = async (id: number) => {
+export const deleteBoard = async (id: number) => {
   const endpoint = `boards?node_id=${id}`;
 
   await csrFetch(endpoint, {
@@ -18,7 +18,11 @@ export const deletePost = async (id: number) => {
   });
 };
 
-export const createPost = async ({ id, title, content }: CreatePostRequest) => {
+export const createBoard = async ({
+  id,
+  title,
+  content,
+}: CreateBoardRequest) => {
   const endpoint = `boards?node_id=${id}`;
   const body = JSON.stringify({
     title,
@@ -31,7 +35,11 @@ export const createPost = async ({ id, title, content }: CreatePostRequest) => {
   });
 };
 
-export const updatePost = async ({ id, title, content }: CreatePostRequest) => {
+export const updateBoard = async ({
+  id,
+  title,
+  content,
+}: CreateBoardRequest) => {
   const endpoint = `boards?node_id=${id}`;
   const body = JSON.stringify({
     title,
@@ -44,7 +52,7 @@ export const updatePost = async ({ id, title, content }: CreatePostRequest) => {
   });
 };
 
-export const getPostListData = async (id?: number) => {
+export const getBoardListData = async (id?: number) => {
   const endpoint = `boards/all?node_id=${id}`;
 
   const data = await csrFetch(endpoint, {
@@ -54,7 +62,7 @@ export const getPostListData = async (id?: number) => {
   return data;
 };
 
-export const getPostData = async (id?: number) => {
+export const getBoardData = async (id?: number) => {
   if (id !== null) {
     const endpoint = `boards/${id}`;
 

--- a/Mindspace_front_next/app/api/hooks/queries/board.ts
+++ b/Mindspace_front_next/app/api/hooks/queries/board.ts
@@ -7,6 +7,7 @@ import {
   getBoard,
   getBoardListData,
   getBoardData,
+  uploadImage,
 } from "@/api/board";
 
 import { BOARD_QUERIES } from "@/constants/queryKeys";
@@ -82,4 +83,8 @@ export const useBoardGetQuery = (boardId?: number) => {
       enabled: boardId !== undefined,
     },
   );
+};
+
+export const useUploadImageMutation = () => {
+  return useMutation(uploadImage);
 };

--- a/Mindspace_front_next/app/api/hooks/queries/board.ts
+++ b/Mindspace_front_next/app/api/hooks/queries/board.ts
@@ -1,32 +1,32 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { APIErrorResponse } from "@/constants/types";
 import {
-  createPost,
-  updatePost,
-  deletePost,
-  getPost,
-  getPostListData,
-  getPostData,
-} from "@/api/post";
+  createBoard,
+  updateBoard,
+  deleteBoard,
+  getBoard,
+  getBoardListData,
+  getBoardData,
+} from "@/api/board";
 
 import { BOARD_QUERIES } from "@/constants/queryKeys";
 
-export const useUserPostGetQuery = (
+export const useUserBoardGetQuery = (
   id: number,
   isOpen: boolean,
   isActive: boolean,
 ) => {
-  return useQuery([BOARD_QUERIES.USER_BOARD(id)], () => getPost(id), {
+  return useQuery([BOARD_QUERIES.USER_BOARD(id)], () => getBoard(id), {
     enabled: isOpen && isActive,
     staleTime: 1000 * 60 * 5,
   });
 };
 
-export const useDeletePostMutation = (
+export const useDeleteBoardMutation = (
   successAction: () => void,
   errorAction: (message: string) => void,
 ) => {
-  return useMutation(deletePost, {
+  return useMutation(deleteBoard, {
     onSuccess: () => {
       successAction();
     },
@@ -36,13 +36,13 @@ export const useDeletePostMutation = (
   });
 };
 
-export const useCreatePostMutation = (
+export const useCreateBoardMutation = (
   successAction: () => void,
   errorAction: (message: string) => void,
 ) => {
   const queryClient = useQueryClient();
 
-  return useMutation(createPost, {
+  return useMutation(createBoard, {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries([BOARD_QUERIES.USER_BOARD(variables.id)]);
       successAction();
@@ -53,10 +53,10 @@ export const useCreatePostMutation = (
   });
 };
 
-export const useUpdatePostMutation = (successAction: () => void) => {
+export const useUpdateBoardMutation = (successAction: () => void) => {
   const queryClient = useQueryClient();
 
-  return useMutation(updatePost, {
+  return useMutation(updateBoard, {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries([BOARD_QUERIES.USER_BOARD(variables.id)]);
       successAction();
@@ -64,20 +64,20 @@ export const useUpdatePostMutation = (successAction: () => void) => {
   });
 };
 
-export const usePostListGetQuery = (nodeId?: number) => {
+export const useBoardListGetQuery = (nodeId?: number) => {
   return useQuery(
     [BOARD_QUERIES.ALL_BOARD(nodeId!)],
-    () => getPostListData(nodeId),
+    () => getBoardListData(nodeId),
     {
       enabled: nodeId !== undefined,
     },
   );
 };
 
-export const usePostGetQuery = (boardId?: number) => {
+export const useBoardGetQuery = (boardId?: number) => {
   return useQuery(
     [BOARD_QUERIES.SINGLE_BOARD(boardId!)],
-    () => getPostData(boardId),
+    () => getBoardData(boardId),
     {
       enabled: boardId !== undefined,
     },

--- a/Mindspace_front_next/app/api/post.ts
+++ b/Mindspace_front_next/app/api/post.ts
@@ -67,3 +67,17 @@ export const getPostData = async (id?: number) => {
     return;
   }
 };
+
+export const uploadImage = async (file: File) => {
+  const endpoint = `boards/image`;
+
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const data = await csrFetch(endpoint, {
+    method: "POST",
+    body: formData,
+  });
+
+  return data;
+};

--- a/Mindspace_front_next/app/api/utils/baseFetch.ts
+++ b/Mindspace_front_next/app/api/utils/baseFetch.ts
@@ -24,11 +24,12 @@ export const baseFetch = async <T = any>(
   endpoint: string,
   headers: HeadersInit,
   options?: RequestInit,
+  skipDefaultHeaders?: boolean,
 ): Promise<T> => {
   const response = await fetch(`${BASEURL}${endpoint}`, {
     ...options,
     headers: new Headers({
-      ...defaultHeaders,
+      ...(skipDefaultHeaders ? {} : defaultHeaders),
       ...headers,
       ...options?.headers,
     }),

--- a/Mindspace_front_next/app/api/utils/csrFetch.ts
+++ b/Mindspace_front_next/app/api/utils/csrFetch.ts
@@ -13,5 +13,12 @@ export const csrFetch = async <T = any>(
     authHeader.user_id = `${accessToken}`;
   }
 
-  return baseFetch<T>(endpoint, authHeader, options);
+  let headers: Record<string, any> = {
+    ...authHeader,
+    ...options?.headers,
+  };
+
+  const skipDefaultHeaders = options?.body instanceof FormData;
+
+  return baseFetch<T>(endpoint, headers, options, skipDefaultHeaders);
 };

--- a/Mindspace_front_next/app/constants/queryKeys.ts
+++ b/Mindspace_front_next/app/constants/queryKeys.ts
@@ -9,7 +9,7 @@ export const NODE_QUERIES = {
 export const BOARD_QUERIES = {
   USER_BOARD: (nodeId: number) => ["USER_BOARD", nodeId],
   ALL_BOARD: (nodeId: number) => ["ALL_BOARD", nodeId],
-  SINGLE_BOARD: (postId: number) => ["SINGLE_BOARD", postId],
+  SINGLE_BOARD: (boardId: number) => ["SINGLE_BOARD", boardId],
 };
 
 /** // TODO - 추가로 각 쿼리키는 아래처럼 도메인단위로 분리하고 사용할 것

--- a/Mindspace_front_next/app/constants/types.ts
+++ b/Mindspace_front_next/app/constants/types.ts
@@ -29,7 +29,7 @@ export interface NicknameResponse {
 
 // Board
 
-export interface CreatePostRequest {
+export interface CreateBoardRequest {
   id: number;
   title: string;
   content: string;

--- a/Mindspace_front_next/app/map/components/BoardTable/index.tsx
+++ b/Mindspace_front_next/app/map/components/BoardTable/index.tsx
@@ -5,20 +5,20 @@ import { CellClickedEvent } from "ag-grid-community";
 import { useRecoilValue } from "recoil";
 import { ModalWidthAtom, ModalHeightAtom } from "@/recoil/state/resizeAtom";
 import { nodeAtom } from "@/recoil/state/nodeAtom";
-import { usePostListGetQuery } from "@/api/hooks/queries/board";
+import { useBoardListGetQuery } from "@/api/hooks/queries/board";
 
 import { formatDateTime, DateTimeFormat } from "@/utils/dateTime";
 import { BoardResponseDto } from "@/constants/types";
-interface PostTableProps {
+interface BoardTableProps {
   onClickedId: (id: number) => void;
 }
 
-function PostTable({ onClickedId }: PostTableProps) {
+function BoardTable({ onClickedId }: BoardTableProps) {
   const selectedNodeInfo = useRecoilValue(nodeAtom);
 
-  const { data: postListData } = usePostListGetQuery(selectedNodeInfo.id);
+  const { data: boardListData } = useBoardListGetQuery(selectedNodeInfo.id);
 
-  const formatPostListData = (dataList: BoardResponseDto[]) => {
+  const formatBoardListData = (dataList: BoardResponseDto[]) => {
     return dataList?.map((data: BoardResponseDto) => ({
       ...data,
       updatedAt: formatDateTime(data.updatedAt, DateTimeFormat.Date),
@@ -50,7 +50,7 @@ function PostTable({ onClickedId }: PostTableProps) {
       }}
     >
       <AgGridReact
-        rowData={formatPostListData(postListData)}
+        rowData={formatBoardListData(boardListData)}
         columnDefs={columnDefs}
         defaultColDef={{
           sortable: true,
@@ -64,4 +64,4 @@ function PostTable({ onClickedId }: PostTableProps) {
   );
 }
 
-export default PostTable;
+export default BoardTable;

--- a/Mindspace_front_next/app/map/components/ListModal/index.tsx
+++ b/Mindspace_front_next/app/map/components/ListModal/index.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useRef } from "react";
-import PostTable from "../PostTable";
+import BoardTable from "../BoardTable";
 import styles from "./ListModal.module.scss";
 import { ListModalProps } from "@/constants/types";
 import { Viewer } from "@toast-ui/react-editor";
 import CustomModal from "@/components/CustomModal";
-import { usePostGetQuery } from "@/api/hooks/queries/board";
+import { useBoardGetQuery } from "@/api/hooks/queries/board";
 
 import { formatDateTime, DateTimeFormat } from "@/utils/dateTime";
 import CommentModal from "../CommentModal";
@@ -12,7 +12,7 @@ import CommentModal from "../CommentModal";
 function ListModal({ listModalOpen, onListRequestClose }: ListModalProps) {
   const [isSelectedTable, setIsSelectedTable] = useState<number>();
   const viewerRef = useRef<Viewer>(null);
-  const { data: postData, isLoading } = usePostGetQuery(isSelectedTable);
+  const { data: boardData, isLoading } = useBoardGetQuery(isSelectedTable);
   const [commentModalOpen, setCommentModalOpen] = useState(false);
   const commentData = [
     {
@@ -39,9 +39,9 @@ function ListModal({ listModalOpen, onListRequestClose }: ListModalProps) {
 
   useEffect(() => {
     if (viewerRef.current) {
-      viewerRef.current.getInstance().setMarkdown(postData?.content);
+      viewerRef.current.getInstance().setMarkdown(boardData?.content);
     }
-  }, [postData?.content]);
+  }, [boardData?.content]);
 
   return (
     <CustomModal
@@ -60,7 +60,7 @@ function ListModal({ listModalOpen, onListRequestClose }: ListModalProps) {
           >
             <span className={styles.header__span}>x</span>
           </button>
-          <PostTable onClickedId={handleSelectBoard} />
+          <BoardTable onClickedId={handleSelectBoard} />
         </>
       ) : (
         !isLoading && (
@@ -89,7 +89,7 @@ function ListModal({ listModalOpen, onListRequestClose }: ListModalProps) {
                           styles.post__wrapper__content__wrapper__header__text__title
                         }
                       >
-                        {postData?.title}
+                        {boardData?.title}
                       </span>
                     </div>
                     <div
@@ -114,7 +114,7 @@ function ListModal({ listModalOpen, onListRequestClose }: ListModalProps) {
                           styles.post__wrapper__content__wrapper__info__name
                         }
                       >
-                        {postData.userNickname}
+                        {boardData.userNickname}
                       </span>
                       <span
                         className={
@@ -122,7 +122,7 @@ function ListModal({ listModalOpen, onListRequestClose }: ListModalProps) {
                         }
                       >
                         {formatDateTime(
-                          postData.updatedAt,
+                          boardData.updatedAt,
                           DateTimeFormat.Date,
                         )}
                       </span>
@@ -131,7 +131,7 @@ function ListModal({ listModalOpen, onListRequestClose }: ListModalProps) {
                   <div className={styles.post__wrapper__viewer}>
                     <Viewer
                       ref={viewerRef}
-                      initialValue={postData?.content}
+                      initialValue={boardData?.content}
                       usageStatistics={false}
                     />
                   </div>

--- a/Mindspace_front_next/app/map/components/WriteModal/WriteModal.module.scss
+++ b/Mindspace_front_next/app/map/components/WriteModal/WriteModal.module.scss
@@ -106,6 +106,21 @@
     position: relative;
     background-color: white;
     border-radius: 0 0 10px 10px;
+
+    &__message {
+      padding: 0;
+      margin: 0;
+      position: absolute;
+      font-size: 0.8rem;
+
+      &__error {
+        color: red;
+      }
+
+      &__loading {
+        color: #423e3e42;
+      }
+    }
   }
 
   .editor__header {

--- a/Mindspace_front_next/app/map/components/WriteModal/WriteModal.module.scss
+++ b/Mindspace_front_next/app/map/components/WriteModal/WriteModal.module.scss
@@ -108,6 +108,21 @@
     border-radius: 0 0 10px 10px;
 
     &__message {
+      @keyframes ellipsis {
+        25% {
+          content: ".";
+        }
+        50% {
+          content: "..";
+        }
+        75% {
+          content: "...";
+        }
+        100% {
+          content: "....";
+        }
+      }
+
       padding: 0;
       margin: 0;
       position: absolute;
@@ -119,6 +134,11 @@
 
       &__loading {
         color: #423e3e42;
+      }
+
+      &__loading::after {
+        content: "....";
+        animation: ellipsis 4s infinite;
       }
     }
   }

--- a/Mindspace_front_next/app/map/components/WriteModal/components/ReadViewer/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/components/ReadViewer/index.tsx
@@ -9,7 +9,7 @@ import styles from "../../WriteModal.module.scss";
 
 import { nodeAtom } from "@/recoil/state/nodeAtom";
 import { useRecoilValue } from "recoil";
-import { useDeletePostMutation } from "@/api/hooks/queries/board";
+import { useDeleteBoardMutation } from "@/api/hooks/queries/board";
 
 import { ReadViewerProps } from "@/constants/types";
 import { formatDateTime, DateTimeFormat } from "@/utils/dateTime";
@@ -23,32 +23,32 @@ const ReadViewer = ({
   const nodeInfo = useRecoilValue(nodeAtom);
   const viewerRef = useRef<any>(null);
 
-  const [createPostErrorMessage, setCreatePostErrorMessage] =
+  const [createBoardErrorMessage, setCreateBoardErrorMessage] =
     useState<string>("");
 
-  const [deletePostErrorMessage, setDeletePostErrorMessage] =
+  const [deleteBoardErrorMessage, setDeleteBoardErrorMessage] =
     useState<string>("");
 
-  const { mutate: deletePostMutation } = useDeletePostMutation(() => {
+  const { mutate: deleteBoardMutation } = useDeleteBoardMutation(() => {
     updateNodeInfo(nodeInfo?.id, false);
     onEditToggle();
     onClose();
-  }, setDeletePostErrorMessage);
+  }, setDeleteBoardErrorMessage);
 
   const handleDelete = () => {
-    deletePostMutation(nodeInfo.id as number);
+    deleteBoardMutation(nodeInfo.id as number);
   };
 
   useEffect(() => {
-    if (createPostErrorMessage) {
-      alert(createPostErrorMessage);
-      setCreatePostErrorMessage("");
+    if (createBoardErrorMessage) {
+      alert(createBoardErrorMessage);
+      setCreateBoardErrorMessage("");
     }
-    if (deletePostErrorMessage) {
-      alert(deletePostErrorMessage);
-      setDeletePostErrorMessage("");
+    if (deleteBoardErrorMessage) {
+      alert(deleteBoardErrorMessage);
+      setDeleteBoardErrorMessage("");
     }
-  }, [createPostErrorMessage, deletePostErrorMessage]);
+  }, [createBoardErrorMessage, deleteBoardErrorMessage]);
 
   useEffect(() => {
     if (viewerRef.current) {

--- a/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
@@ -64,9 +64,16 @@ const WriteEditor = ({
     }
   }, [createBoardErrorMessage]);
 
-  const { mutate: uploadImageMutation } = useUploadImageMutation();
+  const {
+    mutate: uploadImageMutation,
+    isLoading: isImageUploading,
+    isError: isImageUploadError,
+  } = useUploadImageMutation();
 
-  const onUploadImage = async (blob: any, callback: any) => {
+  const onUploadImage = async (
+    blob: File,
+    callback: (imageUrl: string, fileName: string) => void,
+  ) => {
     uploadImageMutation(blob, {
       onSuccess: (data) => {
         callback(data.imageUrl, blob.name);
@@ -126,6 +133,19 @@ const WriteEditor = ({
               usageStatistics={false}
             />
           </div>
+        </div>
+
+        <div className={styles.content__editor__message}>
+          {isImageUploading && (
+            <span className={styles.content__editor__message__loading}>
+              이미지 업로드 중...
+            </span>
+          )}
+          {isImageUploadError && (
+            <span className={styles.content__editor__message__error}>
+              이미지 업로드에 실패하였습니다.
+            </span>
+          )}
         </div>
       </div>
     </>

--- a/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
@@ -7,10 +7,10 @@ import { useRecoilValue } from "recoil";
 import {
   useUpdateBoardMutation,
   useCreateBoardMutation,
+  useUploadImageMutation,
 } from "@/api/hooks/queries/board";
 import { nodeAtom } from "@/recoil/state/nodeAtom";
 import { WriteEditorProps } from "@/constants/types";
-import { uploadImage } from "@/api/board";
 
 const WriteEditor = ({
   nodeData,
@@ -64,11 +64,14 @@ const WriteEditor = ({
     }
   }, [createBoardErrorMessage]);
 
-  const onUploadImage = async (blob: any, callback: any) => {
-    await uploadImage(blob).then((imagePath) => {
-      callback(imagePath.imageUrl, blob.name);
-    });
+  const { mutate: uploadImageMutation } = useUploadImageMutation();
 
+  const onUploadImage = async (blob: any, callback: any) => {
+    uploadImageMutation(blob, {
+      onSuccess: (data) => {
+        callback(data.imageUrl, blob.name);
+      },
+    });
     return false;
   };
   return (

--- a/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/api/hooks/queries/board";
 import { nodeAtom } from "@/recoil/state/nodeAtom";
 import { WriteEditorProps } from "@/constants/types";
+import { uploadImage } from "@/api/post";
 
 const WriteEditor = ({
   nodeData,
@@ -63,6 +64,13 @@ const WriteEditor = ({
     }
   }, [createPostErrorMessage]);
 
+  const onUploadImage = async (blob: any, callback: any) => {
+    await uploadImage(blob).then((imagePath) => {
+      callback(imagePath.imageUrl, blob.name);
+    });
+
+    return false;
+  };
   return (
     <>
       <div className={styles.header}>
@@ -104,6 +112,9 @@ const WriteEditor = ({
             <Editor
               ref={editorRef}
               initialValue={nodeData?.content ?? " "}
+              hooks={{
+                addImageBlobHook: onUploadImage,
+              }}
               placeholder="내용을 입력해 주세요"
               onChange={handleEditorChange}
               previewStyle="tab"

--- a/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
@@ -5,12 +5,12 @@ import { Editor } from "@toast-ui/react-editor";
 import styles from "../../WriteModal.module.scss";
 import { useRecoilValue } from "recoil";
 import {
-  useUpdatePostMutation,
-  useCreatePostMutation,
+  useUpdateBoardMutation,
+  useCreateBoardMutation,
 } from "@/api/hooks/queries/board";
 import { nodeAtom } from "@/recoil/state/nodeAtom";
 import { WriteEditorProps } from "@/constants/types";
-import { uploadImage } from "@/api/post";
+import { uploadImage } from "@/api/board";
 
 const WriteEditor = ({
   nodeData,
@@ -28,27 +28,27 @@ const WriteEditor = ({
     setEditedContent(editorRef?.current?.getInstance().getMarkdown());
   };
 
-  const { mutate: updatePostMutation } = useUpdatePostMutation(() => {
+  const { mutate: updateBoardMutation } = useUpdateBoardMutation(() => {
     onEditToggle();
   });
-  const [createPostErrorMessage, setCreatePostErrorMessage] =
+  const [createBoardErrorMessage, setCreateBoardErrorMessage] =
     useState<string>("");
 
-  const { mutate: createPostMutation } = useCreatePostMutation(() => {
+  const { mutate: createBoardMutation } = useCreateBoardMutation(() => {
     updateNodeInfo(nodeInfo?.id, true);
     onEditToggle();
-  }, setCreatePostErrorMessage);
+  }, setCreateBoardErrorMessage);
 
   const handleSubmit = () => {
     if (nodeInfo.isWritten) {
-      updatePostMutation({
+      updateBoardMutation({
         id: nodeInfo.id as number,
         title: edtedTitle ?? "",
         content: editedContent ?? "",
       });
       updateNodeInfo(nodeInfo?.id, true);
     } else {
-      createPostMutation({
+      createBoardMutation({
         id: nodeInfo.id as number,
         title: edtedTitle ?? "",
         content: editedContent ?? "",
@@ -58,11 +58,11 @@ const WriteEditor = ({
   };
 
   useEffect(() => {
-    if (createPostErrorMessage) {
-      alert(createPostErrorMessage);
-      setCreatePostErrorMessage("");
+    if (createBoardErrorMessage) {
+      alert(createBoardErrorMessage);
+      setCreateBoardErrorMessage("");
     }
-  }, [createPostErrorMessage]);
+  }, [createBoardErrorMessage]);
 
   const onUploadImage = async (blob: any, callback: any) => {
     await uploadImage(blob).then((imagePath) => {

--- a/Mindspace_front_next/app/map/components/WriteModal/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/index.tsx
@@ -8,7 +8,7 @@ import { WriteModalProps } from "@/constants/types";
 import CustomModal from "@/components/CustomModal";
 import { nodeAtom } from "@/recoil/state/nodeAtom";
 import { useRecoilValue } from "recoil";
-import { useUserPostGetQuery } from "@/api/hooks/queries/board";
+import { useUserBoardGetQuery } from "@/api/hooks/queries/board";
 import WriteEditor from "./components/WriteEditor";
 import ReadViewer from "./components/ReadViewer";
 
@@ -20,28 +20,28 @@ const WriteModal = ({
   const nodeInfo = useRecoilValue(nodeAtom);
   const [isEditing, setIsEditing] = useState(false);
 
-  const [createPostErrorMessage, setCreatePostErrorMessage] =
+  const [createBoardErrorMessage, setCreateBoardErrorMessage] =
     useState<string>("");
 
-  const [deletePostErrorMessage, setDeletePostErrorMessage] =
+  const [deleteBoardErrorMessage, setDeleteBoardErrorMessage] =
     useState<string>("");
 
   useEffect(() => {
-    if (createPostErrorMessage) {
-      alert(createPostErrorMessage);
-      setCreatePostErrorMessage("");
+    if (createBoardErrorMessage) {
+      alert(createBoardErrorMessage);
+      setCreateBoardErrorMessage("");
     }
-    if (deletePostErrorMessage) {
-      alert(deletePostErrorMessage);
-      setDeletePostErrorMessage("");
+    if (deleteBoardErrorMessage) {
+      alert(deleteBoardErrorMessage);
+      setDeleteBoardErrorMessage("");
     }
-  }, [createPostErrorMessage, deletePostErrorMessage]);
+  }, [createBoardErrorMessage, deleteBoardErrorMessage]);
 
   const {
-    data: postData,
+    data: boardData,
     isLoading,
     isInitialLoading,
-  } = useUserPostGetQuery(
+  } = useUserBoardGetQuery(
     nodeInfo.id as number,
     isOpen,
     nodeInfo.isWritten ?? false,
@@ -70,10 +70,10 @@ const WriteModal = ({
       {(!isInitialLoading || (isInitialLoading && !isLoading)) && (
         <>
           {nodeInfo.isWritten && !isEditing ? (
-            <ReadViewer nodeData={postData} {...commonProps} />
+            <ReadViewer nodeData={boardData} {...commonProps} />
           ) : (
             <WriteEditor
-              nodeData={isEditing ? postData : undefined}
+              nodeData={isEditing ? boardData : undefined}
               {...commonProps}
             />
           )}


### PR DESCRIPTION
## Summary
이미지 업로드 기능 추가

## Description
- 이미지 업로드 api 연결 및 기능 추가
- 기존의 post 변수,폴더명 board로 통일
- baseFetch 헤더 props 추가

## Screenshots
![feat51:imgUpload](https://github.com/techeer-sv/Mindspace/assets/78795820/c6ab7fe4-91be-4649-9498-4df593037f8d)


## Test Checklist
- [x] 이미지 업로드 기능 테스트


## 기타
- 우선순위는 낮지만 향후 다중 이미지 업로드 기능을 추가하려고 합니다. 라이브러리에서는 단일 이미지 업로드만 지원하네요 ㅜ
- Header설정 관련 이슈 (https://www.notion.so/dr0joon/b901ebc2a9034d9496a02e4199708312) 
