### PR TITLE
[PR] 노드 초기 데이터 init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # neo4j data
 neo4j
+pgdata
 
 # webStorm
 .idea

--- a/Mindspace_back/src/main.ts
+++ b/Mindspace_back/src/main.ts
@@ -1,7 +1,8 @@
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
-import { GlobalExceptionFilter } from './global/common/globalExceptionFilter';
+import { NodeService } from './node/node.service';
+// import { GlobalExceptionFilter } from './global/common/globalExceptionFilter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -24,7 +25,10 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, options);
   SwaggerModule.setup('docs', app, document);
 
-  app.useGlobalFilters(new GlobalExceptionFilter());
+  // FIXME: GlobalExceptionFilter를 사용하면 일부 예외처리가 되지 않아 해결 필요
+  // app.useGlobalFilters(new GlobalExceptionFilter());
+  const nodeService = app.get(NodeService);
+  await nodeService.seedInitialData();
   await app.listen(8000);
 }
 bootstrap();

--- a/Mindspace_back/src/node/node.service.ts
+++ b/Mindspace_back/src/node/node.service.ts
@@ -15,6 +15,55 @@ export class NodeService {
     private readonly nodeMapper: NodeMapper,
   ) {}
 
+  async seedInitialData(): Promise<void> {
+    const existingNodes = await this.nodeRepository.count();
+    if (existingNodes > 0) {
+      // 이미 데이터가 있는 경우 초기화하지 않음
+      return;
+    }
+
+    const initialData = [
+      { id: 1, name: 'Javascript' },
+      { id: 2, name: 'Webpack' },
+      { id: 3, name: 'React' },
+      { id: 4, name: 'JavaScript Immutability' },
+      { id: 5, name: 'Ajax' },
+      { id: 6, name: 'React Route' },
+      { id: 7, name: 'State Management' },
+      { id: 8, name: 'Class vs Component' },
+      { id: 9, name: 'React Query' },
+      { id: 10, name: 'Jest' },
+      { id: 11, name: 'ES6' },
+      { id: 12, name: 'Redux' },
+      { id: 13, name: 'Mobx' },
+      { id: 14, name: 'Zustand' },
+      { id: 15, name: 'Recoil' },
+      { id: 16, name: 'Redux saga' },
+      { id: 17, name: 'Redux toolkit' },
+      { id: 18, name: 'Browser Render' },
+      { id: 19, name: 'HTML' },
+      { id: 20, name: 'Proxy' },
+      { id: 21, name: 'Auth' },
+      { id: 22, name: 'OAuth2.0' },
+      { id: 23, name: 'FaceBook Login' },
+      { id: 24, name: 'Kakao Login' },
+      { id: 25, name: 'Bearer Auth' },
+      { id: 26, name: 'JWT Token' },
+      { id: 27, name: 'CSS' },
+      { id: 28, name: 'CSS vs CSS in JS' },
+      { id: 29, name: 'SASS' },
+      { id: 30, name: 'Tailwind' },
+      { id: 31, name: 'Bootstrap' },
+      { id: 32, name: 'Styled-compoent' },
+      { id: 33, name: 'Material-UI' },
+    ];
+
+    for (const data of initialData) {
+      const newNode = this.nodeRepository.create(data);
+      await this.nodeRepository.save(newNode);
+    }
+  }
+
   async getAllNode(): Promise<NodeResponseDto[]> {
     const nodes = await this.nodeRepository.find();
     return nodes.map((node) => this.nodeMapper.DtoFromEntity(node));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - mindspace-db:/var/lib/postgresql/data
+      - ./:/var/lib/postgresql/data
 
   neo4j:
     container_name: neo4j
@@ -42,6 +42,3 @@ services:
     depends_on:
       - db
       - neo4j
-
-volumes:
-  mindspace-db:


### PR DESCRIPTION
## Summary
노드 초기 데이터의 init이 안되는 문제 해결

## Description
- node.service.ts파일에 노드 초기 데이터를 삽입해서 postgreSQL에 직접 데이터를 넣지 않아도 되도록 해결했습니다.
 https://www.notion.so/dr0joon/node-init-data-35ef856c51f8489aa45e12ff9caacadc?pvs=4 페이지 끝 참고
- 또한 이제 `docker compose down -v`를 해도 기존에 작성한 데이터가 사라지지 않습니다.
- 현재 예외처리를 한 일부가 500에러로 뜨는 문제 때문에 global 예외처리를 main.ts파일에서 제거했습니다.

## 테스트를 하기 위해
1. 프로젝트에서 기존에 사용하던 docker 컨테이너를 내리고 볼륨까지 전부 삭제합니다.
2. 프로젝트에서 사용하던 postgreSQL의 데이터가 저장된 폴더가 있을 경우에 삭제해줍니다. 없으면 패스
3. nest를 도커로 실행했을 때와 로컬로 실행했을 때 문제가 없는지 확인합니다.

## Test Checklist
- [x] nest를 로컬, 도커로 돌렸을 때 각각 회원가입, 로그인, 노드에 게시글 작성 등 모든 동작이 잘 되는지