### PR TITLE
[PR] 댓글/대댓글 삭제 로직 수정

### DIFF
--- a/Mindspace_back/src/comment/comment.controller.ts
+++ b/Mindspace_back/src/comment/comment.controller.ts
@@ -21,7 +21,6 @@ import {
   ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
-import { Comment } from './entities/comment.entity';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 import { PagingParams } from '../global/common/type';
 import { PaginatedCommentResponseDto } from './dto/comment-pagination-response.dto';

--- a/Mindspace_back/src/comment/comment.service.ts
+++ b/Mindspace_back/src/comment/comment.service.ts
@@ -175,7 +175,8 @@ export class CommentService {
   /** 댓글 삭제 */
   async deleteComment(commentId: number, userId: string): Promise<void> {
     const comment: Comment = await this.validateCommentOwner(commentId, userId);
-    await this.commentRepository.remove(comment);
+    comment.content = '삭제된 댓글입니다.';
+    await this.commentRepository.save(comment);
   }
 
   /** 댓글을 찾고 예외를 확인합니다. */

--- a/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
+++ b/Mindspace_back/src/comment/dto/comment.mapper.dto.ts
@@ -36,6 +36,7 @@ export class CommentMapper {
     comment: Comment,
     userId: string,
   ): CommentResponseDto {
+    const isDeletedComment = comment.content === '삭제된 댓글입니다.';
     return {
       id: comment.id,
       userNickname: comment.user.nickname,
@@ -44,7 +45,7 @@ export class CommentMapper {
         addSuffix: true,
         locale: ko,
       }),
-      editable: comment.user.id.toString() === userId,
+      editable: !isDeletedComment && comment.user.id.toString() === userId,
     };
   }
 }


### PR DESCRIPTION
## Summary
댓글/대댓글 삭제 시 "삭제된 댓글입니다"로 변경

## Description
- *댓글/대댓글 삭제 시 "삭제된 댓글입니다"로 변경

## Screenshots
![image](https://github.com/techeer-sv/Mindspace/assets/105929978/7c16437f-726e-4480-935a-438a74cd10c7)

## Test Checklist
- [x] 게시글에 댓글과 대댓글을 삭제하고 댓글을 삭제할 시 "삭제된 댓글입니다"로 content가 변경되는 지