### PR TITLE
[Refactor/#93] 알림 css 수정 및 Editor 초기값 버그 수정

### DIFF
--- a/Mindspace_front_next/app/components/Alarm/Alarm.module.scss
+++ b/Mindspace_front_next/app/components/Alarm/Alarm.module.scss
@@ -10,8 +10,8 @@
     background-color: red;
     border-radius: 50%;
     color: white;
-    font-size: 5px;
-    width: 10px;
+    font-size: 10px;
+    width: 12px;
     height: 15px;
     display: flex;
     align-items: center;

--- a/Mindspace_front_next/app/components/Alarm/index.tsx
+++ b/Mindspace_front_next/app/components/Alarm/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import styles from "./Alarm.module.scss";
 import {
   useAllNotificationQuery,
@@ -19,14 +19,14 @@ const Alarm = () => {
     deleteNotification(notification_id);
   };
 
-  const renderNotificationCount = () => {
-    const count = notificationList.length;
-    return count > 9 ? "+9" : count.toString();
-  };
-
   useNewNotificationPolling();
   const { data: notificationList = [] } = useAllNotificationQuery();
   const { mutate: deleteNotification } = useDeleteNotificationMutation();
+
+  const notificationCount = useMemo(() => {
+    const count = notificationList.length;
+    return count > 9 ? "+9" : count.toString();
+  }, [notificationList.length]);
 
   return (
     <div className={styles.alarm}>
@@ -41,9 +41,7 @@ const Alarm = () => {
           <path d="M12 2C8.1 2 5 5.1 5 9v6l-1 2v1h18v-1l-1-2V9c0-3.9-3.1-7-7-7zm0 18c-1.1 0-2-.9-2-2h4c0 1.1-.9 2-2 2z"></path>
         </svg>
         {notificationList.length > 0 && (
-          <div className={styles.alarm__notification}>
-            {renderNotificationCount()}
-          </div>
+          <div className={styles.alarm__notification}>{notificationCount}</div>
         )}
       </button>
       {isVisible && (

--- a/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
@@ -110,6 +110,18 @@ const WriteEditor = ({
     }
   };
 
+  const onUploadImage = async (
+    blob: File,
+    callback: (imageUrl: string, fileName: string) => void,
+  ) => {
+    uploadImageMutation(blob, {
+      onSuccess: (data) => {
+        callback(data.imageUrl, blob.name);
+      },
+    });
+    return false;
+  };
+
   const {
     mutate: uploadImageMutation,
     isLoading: isImageUploading,
@@ -158,6 +170,9 @@ const WriteEditor = ({
             <Editor
               ref={editorRef}
               placeholder="내용을 입력해 주세요"
+              hooks={{
+                addImageBlobHook: onUploadImage,
+              }}
               onChange={handleEditorChange}
               previewStyle="tab"
               height="100%"

--- a/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
@@ -11,6 +11,8 @@ import {
 import { nodeAtom } from "@/recoil/state/nodeAtom";
 import { WriteEditorProps } from "@/constants/types";
 
+const INIT_EDITOR_VALUE = "";
+
 const WriteEditor = ({
   nodeData,
   onEditToggle,
@@ -66,7 +68,9 @@ const WriteEditor = ({
   useEffect(() => {
     const initialValueSetting = () => {
       if (editorRef?.current) {
-        editorRef?.current?.getInstance().setMarkdown(nodeData?.content ?? "");
+        editorRef?.current
+          ?.getInstance()
+          .setMarkdown(nodeData?.content ?? INIT_EDITOR_VALUE);
       }
     };
 

--- a/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
+++ b/Mindspace_front_next/app/map/components/WriteModal/components/WriteEditor/index.tsx
@@ -63,6 +63,16 @@ const WriteEditor = ({
     }
   }, [createBoardErrorMessage]);
 
+  useEffect(() => {
+    const initialValueSetting = () => {
+      if (editorRef?.current) {
+        editorRef?.current?.getInstance().setMarkdown(nodeData?.content ?? "");
+      }
+    };
+
+    initialValueSetting();
+  }, [nodeData]);
+
   const updateEditorContent = (newContent: string) => {
     const currentContent = editorRef?.current?.getInstance().getMarkdown();
 
@@ -143,7 +153,6 @@ const WriteEditor = ({
           >
             <Editor
               ref={editorRef}
-              initialValue={nodeData?.content ?? " "}
               placeholder="내용을 입력해 주세요"
               onChange={handleEditorChange}
               previewStyle="tab"


### PR DESCRIPTION
## Summary
알림 css 수정 및 Editor 초기값 버그 수정

## Description
- 알림 css 코드 수정, 개수 계산 로직에 useMemo적용
- Editor 초기값에 공백 문자 넣었던 임시처리 수정 및 빈 문자열 할당
- 이미지 다중 업로그 기능구현

## Screenshots


- 알림 개수 css 수정 (크기 키웠어요)
<img width="142" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/78795820/22a1c28d-9734-4993-886a-d5c0538965c2">

- 에디터 초기값 (빈 문자열)

<img width="537" alt="image" src="https://github.com/techeer-sv/Mindspace/assets/78795820/a56c57a9-83b2-40ae-8dd9-ff2c45ac1790">



## Test Checklist
- [x] 알림 css 수정 확인 
- [x] Editor 초기값 확인 ("기존에는 빈 문자열이 들어가 placeholder가 표현되지 않았습니다")