### PR TITLE
fix: 게시글api에서 닉네임이 반환 안되는 이슈 해결

### DIFF
--- a/Mindspace_back/src/board/board.controller.ts
+++ b/Mindspace_back/src/board/board.controller.ts
@@ -103,7 +103,7 @@ export class BoardController {
     @Query() nodeIdDto: NodeIdDto,
     @UserHeader('user_id') userId: string,
     @Body() updateBoardDto: UpdateBoardDto,
-  ): Promise<BoardResponseDto> {
+  ) {
     return this.boardService.updateBoard(
       nodeIdDto.node_id,
       userId,

--- a/Mindspace_back/src/board/board.service.ts
+++ b/Mindspace_back/src/board/board.service.ts
@@ -114,6 +114,7 @@ export class BoardService {
 
     // 게시글 저장 후 반환
     const savedBoard = await this.boardRepository.save(board);
+    console.log(`Board created with ID: ${savedBoard.id}`);
     return BoardMapper.boardToResponseDto(savedBoard);
   }
 

--- a/Mindspace_back/src/board/board.service.ts
+++ b/Mindspace_back/src/board/board.service.ts
@@ -50,9 +50,13 @@ export class BoardService {
       pagingParams,
     );
 
+    console.log('paginationResult -- ', paginationResult);
+
     const data = paginationResult.data.map((board) =>
       BoardMapper.BoardNodeResponseDto(board),
     );
+
+    console.log('data --- ', data);
 
     const cursor = {
       count: paginationResult.data.length,
@@ -111,6 +115,8 @@ export class BoardService {
       existingNode,
       user,
     );
+
+    console.log('service bobarddd -- ', board);
 
     // 게시글 저장 후 반환
     const savedBoard = await this.boardRepository.save(board);
@@ -213,7 +219,9 @@ export class BoardService {
   async getBoardDetailById(boardId: number): Promise<BoardDetailDto> {
     const board = await this.boardRepository.findOne({
       where: { id: boardId },
+      relations: ['user'],
     });
+
     if (!board) {
       throw new NotFoundException(`게시물을 찾을 수 없습니다.`);
     }

--- a/Mindspace_back/src/board/board.service.ts
+++ b/Mindspace_back/src/board/board.service.ts
@@ -50,13 +50,9 @@ export class BoardService {
       pagingParams,
     );
 
-    console.log('paginationResult -- ', paginationResult);
-
     const data = paginationResult.data.map((board) =>
       BoardMapper.BoardNodeResponseDto(board),
     );
-
-    console.log('data --- ', data);
 
     const cursor = {
       count: paginationResult.data.length,
@@ -116,11 +112,8 @@ export class BoardService {
       user,
     );
 
-    console.log('service bobarddd -- ', board);
-
     // 게시글 저장 후 반환
     const savedBoard = await this.boardRepository.save(board);
-    console.log(`Board created with ID: ${savedBoard.id}`);
     return BoardMapper.boardToResponseDto(savedBoard);
   }
 
@@ -128,7 +121,7 @@ export class BoardService {
     nodeId: number,
     userId: string,
     updateBoardDto: UpdateBoardDto,
-  ): Promise<BoardResponseDto> {
+  ): Promise<void> {
     // 노드의 유효성 확인
     const node = await this.nodeService.findById(Number(nodeId));
     if (!node) {
@@ -159,11 +152,7 @@ export class BoardService {
     board.title = updateBoardDto.title;
     board.content = updateBoardDto.content;
 
-    // 변경된 내용 저장
-    const updatedBoard = await this.boardRepository.save(board);
-
-    // 업데이트된 게시글 정보를 DTO로 변환하여 반환
-    return BoardMapper.boardToResponseDto(updatedBoard);
+    await this.boardRepository.save(board);
   }
 
   async deleteOwnBoard(nodeId: number, userId: string): Promise<void> {

--- a/Mindspace_back/src/board/dto/board.mapper.dto.ts
+++ b/Mindspace_back/src/board/dto/board.mapper.dto.ts
@@ -27,7 +27,7 @@ export class BoardMapper {
   static boardToResponseDto(board: Board): BoardResponseDto {
     return {
       id: board.id,
-      userNickname: board.user?.nickname, // user 객체의 nickname 속성 접근
+      userNickname: board.user.nickname, // user 객체의 nickname 속성 접근
       title: board.title,
       content: board.content,
       updatedAt: board.updatedAt,
@@ -37,7 +37,7 @@ export class BoardMapper {
   static BoardNodeResponseDto(board: Board): BoardNodeResponseDto {
     return {
       id: board.id,
-      userNickname: board.user?.nickname, // user 객체의 nickname 속성 접근
+      userNickname: board.user.nickname, // user 객체의 nickname 속성 접근
       title: board.title,
       updatedAt: board.updatedAt,
     };
@@ -55,7 +55,7 @@ export class BoardMapper {
   static toBoardDetailDto(board: Board): BoardDetailDto {
     return {
       id: board.id,
-      userNickname: board.user?.nickname, // user 객체의 nickname 속성 접근
+      userNickname: board.user.nickname, // user 객체의 nickname 속성 접근
       title: board.title,
       content: board.content,
       updatedAt: board.updatedAt,

--- a/Mindspace_back/src/board/repository/board.repository.ts
+++ b/Mindspace_back/src/board/repository/board.repository.ts
@@ -30,7 +30,6 @@ export class CustomBoardRepository {
     });
 
     const paginationResult = await paginator.paginate(queryBuilder);
-    console.log('paginationResult--', paginationResult);
     return {
       data: paginationResult.data,
       cursor: {

--- a/Mindspace_back/src/board/repository/board.repository.ts
+++ b/Mindspace_back/src/board/repository/board.repository.ts
@@ -14,6 +14,7 @@ export class CustomBoardRepository {
 
   async paginate(nodeId: number, pagingParams?: PagingParams) {
     const queryBuilder = this.BoardRepository.createQueryBuilder('board')
+      .leftJoinAndSelect('board.user', 'user')
       .where('board.node_id = :nodeId', { nodeId })
       .orderBy('board.id', 'DESC');
 
@@ -29,7 +30,7 @@ export class CustomBoardRepository {
     });
 
     const paginationResult = await paginator.paginate(queryBuilder);
-
+    console.log('paginationResult--', paginationResult);
     return {
       data: paginationResult.data,
       cursor: {


### PR DESCRIPTION
## Summary
- 특정 게시글 조회 & 노드별 모든 게시글 조회 api에서 사용자 닉네임이 반환 안되고 있는 문제 해결

- 게시글 수정 api 반환값 수정

## Description
- 사용자 객체를 가질 수 있도록 코드 수정
- 불필요한 옵셔널 체이닝(?) 제거
- 기존에 response로 보냈던 수정된 게시글 정보를 사용하지 않고 다시 get으로 조회해서 사용하고 있다해서 delete와 동일하게 httpstatus만 반환하도록 수정 

## Screenshots
*노드별 모든 게시글 조회*
<img width="458" alt="스크린샷 2023-11-27 00 54 25" src="https://github.com/techeer-sv/Mindspace/assets/98005864/3a68835c-9173-4d02-bccb-2616c5175b99">

*특정 게시글 조회*
<img width="388" alt="스크린샷 2023-11-27 00 54 44" src="https://github.com/techeer-sv/Mindspace/assets/98005864/bdf7c481-f723-490f-8f49-a978617769b2">

*게시글 수정*
<img width="561" alt="스크린샷 2023-11-27 00 54 07" src="https://github.com/techeer-sv/Mindspace/assets/98005864/187d05dc-33af-483c-b0f1-4700cb87af0c">


## Test Checklist
- [x] 특정 게시글 조회 & 노드별 모든 게시글 조회 api에서 사용자 닉네임이 반환되는지
- [x] 게시글 수정이 잘 되는지